### PR TITLE
Update cf-k8s-controllers imports

### DIFF
--- a/apis/app_handler_test.go
+++ b/apis/app_handler_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/api/v1alpha1"
+	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/workloads/v1alpha1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"code.cloudfoundry.org/cf-k8s-api/apis"

--- a/apis/route_handler_test.go
+++ b/apis/route_handler_test.go
@@ -13,7 +13,7 @@ import (
 	"code.cloudfoundry.org/cf-k8s-api/apis"
 	"code.cloudfoundry.org/cf-k8s-api/presenters"
 	"code.cloudfoundry.org/cf-k8s-api/repositories"
-	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/api/v1alpha1"
+	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/networking/v1alpha1"
 	. "github.com/onsi/gomega"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
@@ -27,13 +27,13 @@ type FakeRouteRepo struct {
 }
 
 func (f *FakeRouteRepo) ConfigureClient(_ *rest.Config) (client.Client, error) {
-	err := workloadsv1alpha1.AddToScheme(scheme.Scheme)
+	err := networkingv1alpha1.AddToScheme(scheme.Scheme)
 	if err != nil {
 		return nil, err
 	}
 
 	fakeClientBuilder := &fake.ClientBuilder{}
-	return fakeClientBuilder.WithScheme(scheme.Scheme).WithObjects(&workloadsv1alpha1.CFRoute{}).Build(), nil
+	return fakeClientBuilder.WithScheme(scheme.Scheme).WithObjects(&networkingv1alpha1.CFRoute{}).Build(), nil
 }
 
 func (f *FakeRouteRepo) FetchRoute(client client.Client, routeGUID string) (repositories.RouteRecord, error) {
@@ -45,13 +45,13 @@ type FakeDomainRepo struct {
 }
 
 func (f *FakeDomainRepo) ConfigureClient(_ *rest.Config) (client.Client, error) {
-	err := workloadsv1alpha1.AddToScheme(scheme.Scheme)
+	err := networkingv1alpha1.AddToScheme(scheme.Scheme)
 	if err != nil {
 		return nil, err
 	}
 
 	fakeClientBuilder := &fake.ClientBuilder{}
-	return fakeClientBuilder.WithScheme(scheme.Scheme).WithObjects(&workloadsv1alpha1.CFRoute{}).Build(), nil
+	return fakeClientBuilder.WithScheme(scheme.Scheme).WithObjects(&networkingv1alpha1.CFRoute{}).Build(), nil
 }
 
 func (f *FakeDomainRepo) FetchDomain(client client.Client, domainGUID string) (repositories.DomainRecord, error) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module code.cloudfoundry.org/cf-k8s-api
 go 1.16
 
 require (
-	code.cloudfoundry.org/cf-k8s-controllers v0.0.0-20210826202621-aa5e1d3837a2
+	code.cloudfoundry.org/cf-k8s-controllers v0.0.0-20210902233618-f822f3073471
 	github.com/Azure/go-autorest/autorest/adal v0.9.13 // indirect
 	github.com/go-logr/logr v0.4.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 code.cloudfoundry.org/cf-k8s-controllers v0.0.0-20210826202621-aa5e1d3837a2 h1:IcJSmPhvBfHcC2oBuBJ/j3IgQhvrNdvF+0GbUvbTYhk=
 code.cloudfoundry.org/cf-k8s-controllers v0.0.0-20210826202621-aa5e1d3837a2/go.mod h1:t8NasZwSp79Fq8hGwC7HkuXx8oK8+pchXKgeIlQHz/4=
+code.cloudfoundry.org/cf-k8s-controllers v0.0.0-20210902233618-f822f3073471 h1:DO+8/MIMk9hGixJpDYBnoNF9sB05jHjxEo5kIktY0T4=
+code.cloudfoundry.org/cf-k8s-controllers v0.0.0-20210902233618-f822f3073471/go.mod h1:M4f90LhYf7bexEm3CVBONBjn9gzlX2urTCUD1Iy8Dg8=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=

--- a/main.go
+++ b/main.go
@@ -9,7 +9,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/api/v1alpha1"
+	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/networking/v1alpha1"
+	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/workloads/v1alpha1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"code.cloudfoundry.org/cf-k8s-api/apis"
@@ -24,6 +25,7 @@ const defaultConfigPath = "config.json"
 
 func init() {
 	utilruntime.Must(workloadsv1alpha1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(networkingv1alpha1.AddToScheme(scheme.Scheme))
 }
 
 func main() {

--- a/repositories/app_repository.go
+++ b/repositories/app_repository.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/api/v1alpha1"
+	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/workloads/v1alpha1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/repositories/app_repository_test.go
+++ b/repositories/app_repository_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/api/v1alpha1"
+	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/workloads/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/repositories/domain_repository.go
+++ b/repositories/domain_repository.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/api/v1alpha1"
+	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/networking/v1alpha1"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -33,7 +33,7 @@ func (r *DomainRepo) ConfigureClient(config *rest.Config) (client.Client, error)
 }
 
 func (f *DomainRepo) FetchDomain(client client.Client, domainGUID string) (DomainRecord, error) {
-	cfDomainList := &workloadsv1alpha1.CFDomainList{}
+	cfDomainList := &networkingv1alpha1.CFDomainList{}
 	err := client.List(context.Background(), cfDomainList)
 
 	if err != nil {
@@ -46,8 +46,8 @@ func (f *DomainRepo) FetchDomain(client client.Client, domainGUID string) (Domai
 	return f.returnDomain(filteredDomainList)
 }
 
-func (f *DomainRepo) filterByDomainName(domainList []workloadsv1alpha1.CFDomain, name string) []workloadsv1alpha1.CFDomain {
-	filtered := []workloadsv1alpha1.CFDomain{}
+func (f *DomainRepo) filterByDomainName(domainList []networkingv1alpha1.CFDomain, name string) []networkingv1alpha1.CFDomain {
+	filtered := []networkingv1alpha1.CFDomain{}
 
 	for i, domain := range domainList {
 		if domain.Name == name {
@@ -58,7 +58,7 @@ func (f *DomainRepo) filterByDomainName(domainList []workloadsv1alpha1.CFDomain,
 	return filtered
 }
 
-func (f *DomainRepo) returnDomain(domainList []workloadsv1alpha1.CFDomain) (DomainRecord, error) {
+func (f *DomainRepo) returnDomain(domainList []networkingv1alpha1.CFDomain) (DomainRecord, error) {
 	if len(domainList) == 0 {
 		return DomainRecord{}, NotFoundError{Err: errors.New("not found")}
 	}
@@ -66,7 +66,7 @@ func (f *DomainRepo) returnDomain(domainList []workloadsv1alpha1.CFDomain) (Doma
 	return cfDomainToDomainRecord(domainList[0]), nil
 }
 
-func cfDomainToDomainRecord(cfDomain workloadsv1alpha1.CFDomain) DomainRecord {
+func cfDomainToDomainRecord(cfDomain networkingv1alpha1.CFDomain) DomainRecord {
 	return DomainRecord{
 		Name:      cfDomain.Spec.Name,
 		GUID:      cfDomain.Name,

--- a/repositories/domain_repository_test.go
+++ b/repositories/domain_repository_test.go
@@ -1,7 +1,7 @@
 package repositories_test
 
 import (
-	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/api/v1alpha1"
+	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/networking/v1alpha1"
 	"context"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
@@ -17,28 +17,28 @@ var _ = SuiteDescribe("Domain API Shim", func(t *testing.T, when spec.G, it spec
 
 	when("multiple CFDomain resources exist", func() {
 		var (
-			cfDomain1 *workloadsv1alpha1.CFDomain
-			cfDomain2 *workloadsv1alpha1.CFDomain
+			cfDomain1 *networkingv1alpha1.CFDomain
+			cfDomain2 *networkingv1alpha1.CFDomain
 		)
 
 		it.Before(func() {
 			ctx := context.Background()
 
-			cfDomain1 = &workloadsv1alpha1.CFDomain{
+			cfDomain1 = &networkingv1alpha1.CFDomain{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "domain-id-1",
 				},
-				Spec: workloadsv1alpha1.CFDomainSpec{
+				Spec: networkingv1alpha1.CFDomainSpec{
 					Name: "my-domain-1",
 				},
 			}
 			g.Expect(k8sClient.Create(ctx, cfDomain1)).To(Succeed())
 
-			cfDomain2 = &workloadsv1alpha1.CFDomain{
+			cfDomain2 = &networkingv1alpha1.CFDomain{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "domain-id-2",
 				},
-				Spec: workloadsv1alpha1.CFDomainSpec{
+				Spec: networkingv1alpha1.CFDomainSpec{
 
 					Name: "my-domain-2",
 				},

--- a/repositories/fixtures/vendir.lock.yml
+++ b/repositories/fixtures/vendir.lock.yml
@@ -2,9 +2,8 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: Issues/8 Introduced a validating webhook for spec.Name uniqueness
-        (#34)...
-      sha: df7c438fb59fcd2c357154a521de6cf8970f9638
+      commitTitle: 'Merge pull request #37 from cloudfoundry/code-cleanup...'
+      sha: 06cf18e889e64fd0d6edda85bf7367a2f5197e67
     path: cf-k8s-controllers
   path: vendor
 kind: LockConfig

--- a/repositories/fixtures/vendor/cf-k8s-controllers/config/crd/bases/networking.cloudfoundry.org_cfdomains.yaml
+++ b/repositories/fixtures/vendor/cf-k8s-controllers/config/crd/bases/networking.cloudfoundry.org_cfdomains.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
-  name: cfdomains.workloads.cloudfoundry.org
+  name: cfdomains.networking.cloudfoundry.org
 spec:
-  group: workloads.cloudfoundry.org
+  group: networking.cloudfoundry.org
   names:
     kind: CFDomain
     listKind: CFDomainList

--- a/repositories/fixtures/vendor/cf-k8s-controllers/config/crd/bases/networking.cloudfoundry.org_cfroutes.yaml
+++ b/repositories/fixtures/vendor/cf-k8s-controllers/config/crd/bases/networking.cloudfoundry.org_cfroutes.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
-  name: cfroutes.workloads.cloudfoundry.org
+  name: cfroutes.networking.cloudfoundry.org
 spec:
-  group: workloads.cloudfoundry.org
+  group: networking.cloudfoundry.org
   names:
     kind: CFRoute
     listKind: CFRouteList
@@ -41,9 +41,8 @@ spec:
                       description: App ref is required, part of the identity of a running process to which traffic may be routed We use a ref because the app must exist
                       properties:
                         name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
-                      required:
-                      - name
                       type: object
                     port:
                       description: Port is optional, defaults to ProcessModel::DEFAULT_HTTP_PORT
@@ -60,9 +59,8 @@ spec:
                 description: Domain ref is required, provides base domain name and allowed protocol info.
                 properties:
                   name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
-                required:
-                - name
                 type: object
               host:
                 description: Host is optional, defaults to empty. For cf push default route, uses the name of the app.

--- a/repositories/route_repository.go
+++ b/repositories/route_repository.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/api/v1alpha1"
+	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/networking/v1alpha1"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -45,7 +45,7 @@ func (f *RouteRepo) ConfigureClient(config *rest.Config) (client.Client, error) 
 
 func (f *RouteRepo) FetchRoute(client client.Client, routeGUID string) (RouteRecord, error) {
 	// TODO: Could look up namespace from guid => namespace cache to do Get
-	cfRouteList := &workloadsv1alpha1.CFRouteList{}
+	cfRouteList := &networkingv1alpha1.CFRouteList{}
 	err := client.List(context.Background(), cfRouteList)
 
 	if err != nil {
@@ -64,8 +64,8 @@ func (r RouteRecord) UpdateDomainRef(d DomainRecord) RouteRecord {
 	return r
 }
 
-func (f *RouteRepo) filterByRouteName(routeList []workloadsv1alpha1.CFRoute, name string) []workloadsv1alpha1.CFRoute {
-	var filtered []workloadsv1alpha1.CFRoute
+func (f *RouteRepo) filterByRouteName(routeList []networkingv1alpha1.CFRoute, name string) []networkingv1alpha1.CFRoute {
+	var filtered []networkingv1alpha1.CFRoute
 
 	for i, route := range routeList {
 		if route.Name == name {
@@ -76,7 +76,7 @@ func (f *RouteRepo) filterByRouteName(routeList []workloadsv1alpha1.CFRoute, nam
 	return filtered
 }
 
-func (f *RouteRepo) returnRoute(routeList []workloadsv1alpha1.CFRoute) (RouteRecord, error) {
+func (f *RouteRepo) returnRoute(routeList []networkingv1alpha1.CFRoute) (RouteRecord, error) {
 	if len(routeList) == 0 {
 		return RouteRecord{}, NotFoundError{Err: errors.New("not found")}
 	}
@@ -88,7 +88,7 @@ func (f *RouteRepo) returnRoute(routeList []workloadsv1alpha1.CFRoute) (RouteRec
 	return cfRouteToRouteRecord(routeList[0]), nil
 }
 
-func cfRouteToRouteRecord(cfRoute workloadsv1alpha1.CFRoute) RouteRecord {
+func cfRouteToRouteRecord(cfRoute networkingv1alpha1.CFRoute) RouteRecord {
 	return RouteRecord{
 		GUID:      cfRoute.Name,
 		SpaceGUID: cfRoute.Namespace,

--- a/repositories/route_repository_test.go
+++ b/repositories/route_repository_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"code.cloudfoundry.org/cf-k8s-api/repositories"
-	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/api/v1alpha1"
+	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/networking/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -18,43 +18,43 @@ var _ = SuiteDescribe("Route API Shim", func(t *testing.T, when spec.G, it spec.
 
 	when("multiple CFRoute resources exist", func() {
 		var (
-			cfRoute1 *workloadsv1alpha1.CFRoute
-			cfRoute2 *workloadsv1alpha1.CFRoute
+			cfRoute1 *networkingv1alpha1.CFRoute
+			cfRoute2 *networkingv1alpha1.CFRoute
 		)
 
 		it.Before(func() {
 			ctx := context.Background()
 
-			cfRoute1 = &workloadsv1alpha1.CFRoute{
+			cfRoute1 = &networkingv1alpha1.CFRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "route-id-1",
 					Namespace: "default",
 				},
-				Spec: workloadsv1alpha1.CFRouteSpec{
+				Spec: networkingv1alpha1.CFRouteSpec{
 					Host:     "my-subdomain-1",
 					Path:     "",
 					Protocol: "http",
-					DomainRef: workloadsv1alpha1.ResourceReference{
+					DomainRef: corev1.LocalObjectReference{
 						Name: "my-domain",
 					},
-					Destinations: []workloadsv1alpha1.Destination{},
+					Destinations: []networkingv1alpha1.Destination{},
 				},
 			}
 			g.Expect(k8sClient.Create(ctx, cfRoute1)).To(Succeed())
 
-			cfRoute2 = &workloadsv1alpha1.CFRoute{
+			cfRoute2 = &networkingv1alpha1.CFRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "route-id-2",
 					Namespace: "default",
 				},
-				Spec: workloadsv1alpha1.CFRouteSpec{
+				Spec: networkingv1alpha1.CFRouteSpec{
 					Host:     "my-subdomain-2",
 					Path:     "",
 					Protocol: "http",
-					DomainRef: workloadsv1alpha1.ResourceReference{
+					DomainRef: corev1.LocalObjectReference{
 						Name: "my-domain",
 					},
-					Destinations: []workloadsv1alpha1.Destination{},
+					Destinations: []networkingv1alpha1.Destination{},
 				},
 			}
 			g.Expect(k8sClient.Create(ctx, cfRoute2)).To(Succeed())
@@ -98,8 +98,8 @@ var _ = SuiteDescribe("Route API Shim", func(t *testing.T, when spec.G, it spec.
 
 	when("multiple CFRoute resources exist across namespaces with the same name", func() {
 		var (
-			cfRoute1            *workloadsv1alpha1.CFRoute
-			cfRoute2            *workloadsv1alpha1.CFRoute
+			cfRoute1            *networkingv1alpha1.CFRoute
+			cfRoute2            *networkingv1alpha1.CFRoute
 			nonDefaultNamespace *corev1.Namespace
 		)
 
@@ -109,36 +109,36 @@ var _ = SuiteDescribe("Route API Shim", func(t *testing.T, when spec.G, it spec.
 			nonDefaultNamespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "non-default-namespace"}}
 			g.Expect(k8sClient.Create(ctx, nonDefaultNamespace)).To(Succeed())
 
-			cfRoute1 = &workloadsv1alpha1.CFRoute{
+			cfRoute1 = &networkingv1alpha1.CFRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "non-unique-route-id",
 					Namespace: "default",
 				},
-				Spec: workloadsv1alpha1.CFRouteSpec{
+				Spec: networkingv1alpha1.CFRouteSpec{
 					Host:     "",
 					Path:     "",
 					Protocol: "http",
-					DomainRef: workloadsv1alpha1.ResourceReference{
+					DomainRef: corev1.LocalObjectReference{
 						Name: "my-domain",
 					},
-					Destinations: []workloadsv1alpha1.Destination{},
+					Destinations: []networkingv1alpha1.Destination{},
 				},
 			}
 			g.Expect(k8sClient.Create(ctx, cfRoute1)).To(Succeed())
 
-			cfRoute2 = &workloadsv1alpha1.CFRoute{
+			cfRoute2 = &networkingv1alpha1.CFRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "non-unique-route-id",
 					Namespace: "non-default-namespace",
 				},
-				Spec: workloadsv1alpha1.CFRouteSpec{
+				Spec: networkingv1alpha1.CFRouteSpec{
 					Host:     "",
 					Path:     "",
 					Protocol: "http",
-					DomainRef: workloadsv1alpha1.ResourceReference{
+					DomainRef: corev1.LocalObjectReference{
 						Name: "my-domain",
 					},
-					Destinations: []workloadsv1alpha1.Destination{},
+					Destinations: []networkingv1alpha1.Destination{},
 				},
 			}
 			g.Expect(k8sClient.Create(ctx, cfRoute2)).To(Succeed())

--- a/repositories/suite_test.go
+++ b/repositories/suite_test.go
@@ -5,7 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/api/v1alpha1"
+	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/networking/v1alpha1"
+	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/workloads/v1alpha1"
 	. "github.com/onsi/gomega"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -60,6 +61,8 @@ func beforeSuite(g *WithT) *envtest.Environment {
 	g.Expect(k8sConfig).NotTo(BeNil())
 
 	err = workloadsv1alpha1.AddToScheme(scheme.Scheme)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = networkingv1alpha1.AddToScheme(scheme.Scheme)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	k8sClient, err = client.New(k8sConfig, client.Options{Scheme: scheme.Scheme})


### PR DESCRIPTION
Follow up to https://github.com/cloudfoundry/cf-k8s-controllers/issues/27

Co-authored-by: Ashwin Krishna <krishnaas@vmware.com>

## Is there a related GitHub Issue?
Follow up to https://github.com/cloudfoundry/cf-k8s-controllers/issues/27

There is no new issue in this repo. Just an update chore.

## What is this change about?
Update the cf-k8s-controllers imports and reflect package organization changes in our code

## Does this PR introduce a breaking change?
No, changes should be purely cosmetic. Symbols for different api group imports now have distinct names.

## Acceptance Steps
`make` continues to successfully run

## Tag your pair, your PM, and/or team
cc @akrishna90 and @gnovv as folks that will see merge conflicts as a result of the changes
