### PR TITLE
test-build-push-pr workflow update image tag

### DIFF
--- a/.github/workflows/test-build-push-pr.yml
+++ b/.github/workflows/test-build-push-pr.yml
@@ -54,4 +54,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: relintdockerhubpushbot/cf-k8s-api:${{ github.head_ref }}
+          tags: relintdockerhubpushbot/cf-k8s-api:pr-${{ github.event.number }}


### PR DESCRIPTION
## What is this change about?
Change workflow to tag images with PR number instead of branch name.

## Does this PR introduce a breaking change?
No.
