### PR TITLE
Added RBAC for fetchign Namespaces

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,14 @@ metadata:
   name: cf-admin-clusterrole
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - networking.cloudfoundry.org
   resources:
   - cfdomains

--- a/repositories/shared.go
+++ b/repositories/shared.go
@@ -7,6 +7,8 @@ import (
 
 //go:generate controller-gen rbac:roleName=cf-admin-clusterrole paths=./... output:rbac:artifacts:config=../config/rbac
 
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+
 type NotFoundError struct {
 	Err error
 }


### PR DESCRIPTION
## Is there a related GitHub Issue?
#64 

## What is this change about?
This resolves an RBAC issue in the shim that prevented `Namespace` lookups.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Deploy as normal, then run:
(Note: the namespace needs to be created first)

curl "<cluster-ip>/v3/apps" \
-H "Content-type: application/json" \
-d '{
    "name": "my_app",
    "relationships": {
      "space": {
        "data": {
          "guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
        }
      }
    }
  }' 

## Tag your pair, your PM, and/or team
@PureMunky 
