### PR TITLE
Refactor interfaces to take ctx as first arg

### DIFF
--- a/apis/fake/cfapp_repository.go
+++ b/apis/fake/cfapp_repository.go
@@ -11,11 +11,11 @@ import (
 )
 
 type CFAppRepository struct {
-	AppExistsStub        func(client.Client, context.Context, string, string) (bool, error)
+	AppExistsStub        func(context.Context, client.Client, string, string) (bool, error)
 	appExistsMutex       sync.RWMutex
 	appExistsArgsForCall []struct {
-		arg1 client.Client
-		arg2 context.Context
+		arg1 context.Context
+		arg2 client.Client
 		arg3 string
 		arg4 string
 	}
@@ -27,11 +27,11 @@ type CFAppRepository struct {
 		result1 bool
 		result2 error
 	}
-	CreateAppStub        func(client.Client, context.Context, repositories.AppRecord) (repositories.AppRecord, error)
+	CreateAppStub        func(context.Context, client.Client, repositories.AppRecord) (repositories.AppRecord, error)
 	createAppMutex       sync.RWMutex
 	createAppArgsForCall []struct {
-		arg1 client.Client
-		arg2 context.Context
+		arg1 context.Context
+		arg2 client.Client
 		arg3 repositories.AppRecord
 	}
 	createAppReturns struct {
@@ -42,11 +42,11 @@ type CFAppRepository struct {
 		result1 repositories.AppRecord
 		result2 error
 	}
-	CreateAppEnvironmentVariablesStub        func(client.Client, context.Context, repositories.AppEnvVarsRecord) (repositories.AppEnvVarsRecord, error)
+	CreateAppEnvironmentVariablesStub        func(context.Context, client.Client, repositories.AppEnvVarsRecord) (repositories.AppEnvVarsRecord, error)
 	createAppEnvironmentVariablesMutex       sync.RWMutex
 	createAppEnvironmentVariablesArgsForCall []struct {
-		arg1 client.Client
-		arg2 context.Context
+		arg1 context.Context
+		arg2 client.Client
 		arg3 repositories.AppEnvVarsRecord
 	}
 	createAppEnvironmentVariablesReturns struct {
@@ -57,11 +57,11 @@ type CFAppRepository struct {
 		result1 repositories.AppEnvVarsRecord
 		result2 error
 	}
-	FetchAppStub        func(client.Client, context.Context, string) (repositories.AppRecord, error)
+	FetchAppStub        func(context.Context, client.Client, string) (repositories.AppRecord, error)
 	fetchAppMutex       sync.RWMutex
 	fetchAppArgsForCall []struct {
-		arg1 client.Client
-		arg2 context.Context
+		arg1 context.Context
+		arg2 client.Client
 		arg3 string
 	}
 	fetchAppReturns struct {
@@ -72,11 +72,11 @@ type CFAppRepository struct {
 		result1 repositories.AppRecord
 		result2 error
 	}
-	FetchNamespaceStub        func(client.Client, context.Context, string) (repositories.SpaceRecord, error)
+	FetchNamespaceStub        func(context.Context, client.Client, string) (repositories.SpaceRecord, error)
 	fetchNamespaceMutex       sync.RWMutex
 	fetchNamespaceArgsForCall []struct {
-		arg1 client.Client
-		arg2 context.Context
+		arg1 context.Context
+		arg2 client.Client
 		arg3 string
 	}
 	fetchNamespaceReturns struct {
@@ -91,12 +91,12 @@ type CFAppRepository struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *CFAppRepository) AppExists(arg1 client.Client, arg2 context.Context, arg3 string, arg4 string) (bool, error) {
+func (fake *CFAppRepository) AppExists(arg1 context.Context, arg2 client.Client, arg3 string, arg4 string) (bool, error) {
 	fake.appExistsMutex.Lock()
 	ret, specificReturn := fake.appExistsReturnsOnCall[len(fake.appExistsArgsForCall)]
 	fake.appExistsArgsForCall = append(fake.appExistsArgsForCall, struct {
-		arg1 client.Client
-		arg2 context.Context
+		arg1 context.Context
+		arg2 client.Client
 		arg3 string
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
@@ -119,13 +119,13 @@ func (fake *CFAppRepository) AppExistsCallCount() int {
 	return len(fake.appExistsArgsForCall)
 }
 
-func (fake *CFAppRepository) AppExistsCalls(stub func(client.Client, context.Context, string, string) (bool, error)) {
+func (fake *CFAppRepository) AppExistsCalls(stub func(context.Context, client.Client, string, string) (bool, error)) {
 	fake.appExistsMutex.Lock()
 	defer fake.appExistsMutex.Unlock()
 	fake.AppExistsStub = stub
 }
 
-func (fake *CFAppRepository) AppExistsArgsForCall(i int) (client.Client, context.Context, string, string) {
+func (fake *CFAppRepository) AppExistsArgsForCall(i int) (context.Context, client.Client, string, string) {
 	fake.appExistsMutex.RLock()
 	defer fake.appExistsMutex.RUnlock()
 	argsForCall := fake.appExistsArgsForCall[i]
@@ -158,12 +158,12 @@ func (fake *CFAppRepository) AppExistsReturnsOnCall(i int, result1 bool, result2
 	}{result1, result2}
 }
 
-func (fake *CFAppRepository) CreateApp(arg1 client.Client, arg2 context.Context, arg3 repositories.AppRecord) (repositories.AppRecord, error) {
+func (fake *CFAppRepository) CreateApp(arg1 context.Context, arg2 client.Client, arg3 repositories.AppRecord) (repositories.AppRecord, error) {
 	fake.createAppMutex.Lock()
 	ret, specificReturn := fake.createAppReturnsOnCall[len(fake.createAppArgsForCall)]
 	fake.createAppArgsForCall = append(fake.createAppArgsForCall, struct {
-		arg1 client.Client
-		arg2 context.Context
+		arg1 context.Context
+		arg2 client.Client
 		arg3 repositories.AppRecord
 	}{arg1, arg2, arg3})
 	stub := fake.CreateAppStub
@@ -185,13 +185,13 @@ func (fake *CFAppRepository) CreateAppCallCount() int {
 	return len(fake.createAppArgsForCall)
 }
 
-func (fake *CFAppRepository) CreateAppCalls(stub func(client.Client, context.Context, repositories.AppRecord) (repositories.AppRecord, error)) {
+func (fake *CFAppRepository) CreateAppCalls(stub func(context.Context, client.Client, repositories.AppRecord) (repositories.AppRecord, error)) {
 	fake.createAppMutex.Lock()
 	defer fake.createAppMutex.Unlock()
 	fake.CreateAppStub = stub
 }
 
-func (fake *CFAppRepository) CreateAppArgsForCall(i int) (client.Client, context.Context, repositories.AppRecord) {
+func (fake *CFAppRepository) CreateAppArgsForCall(i int) (context.Context, client.Client, repositories.AppRecord) {
 	fake.createAppMutex.RLock()
 	defer fake.createAppMutex.RUnlock()
 	argsForCall := fake.createAppArgsForCall[i]
@@ -224,12 +224,12 @@ func (fake *CFAppRepository) CreateAppReturnsOnCall(i int, result1 repositories.
 	}{result1, result2}
 }
 
-func (fake *CFAppRepository) CreateAppEnvironmentVariables(arg1 client.Client, arg2 context.Context, arg3 repositories.AppEnvVarsRecord) (repositories.AppEnvVarsRecord, error) {
+func (fake *CFAppRepository) CreateAppEnvironmentVariables(arg1 context.Context, arg2 client.Client, arg3 repositories.AppEnvVarsRecord) (repositories.AppEnvVarsRecord, error) {
 	fake.createAppEnvironmentVariablesMutex.Lock()
 	ret, specificReturn := fake.createAppEnvironmentVariablesReturnsOnCall[len(fake.createAppEnvironmentVariablesArgsForCall)]
 	fake.createAppEnvironmentVariablesArgsForCall = append(fake.createAppEnvironmentVariablesArgsForCall, struct {
-		arg1 client.Client
-		arg2 context.Context
+		arg1 context.Context
+		arg2 client.Client
 		arg3 repositories.AppEnvVarsRecord
 	}{arg1, arg2, arg3})
 	stub := fake.CreateAppEnvironmentVariablesStub
@@ -251,13 +251,13 @@ func (fake *CFAppRepository) CreateAppEnvironmentVariablesCallCount() int {
 	return len(fake.createAppEnvironmentVariablesArgsForCall)
 }
 
-func (fake *CFAppRepository) CreateAppEnvironmentVariablesCalls(stub func(client.Client, context.Context, repositories.AppEnvVarsRecord) (repositories.AppEnvVarsRecord, error)) {
+func (fake *CFAppRepository) CreateAppEnvironmentVariablesCalls(stub func(context.Context, client.Client, repositories.AppEnvVarsRecord) (repositories.AppEnvVarsRecord, error)) {
 	fake.createAppEnvironmentVariablesMutex.Lock()
 	defer fake.createAppEnvironmentVariablesMutex.Unlock()
 	fake.CreateAppEnvironmentVariablesStub = stub
 }
 
-func (fake *CFAppRepository) CreateAppEnvironmentVariablesArgsForCall(i int) (client.Client, context.Context, repositories.AppEnvVarsRecord) {
+func (fake *CFAppRepository) CreateAppEnvironmentVariablesArgsForCall(i int) (context.Context, client.Client, repositories.AppEnvVarsRecord) {
 	fake.createAppEnvironmentVariablesMutex.RLock()
 	defer fake.createAppEnvironmentVariablesMutex.RUnlock()
 	argsForCall := fake.createAppEnvironmentVariablesArgsForCall[i]
@@ -290,12 +290,12 @@ func (fake *CFAppRepository) CreateAppEnvironmentVariablesReturnsOnCall(i int, r
 	}{result1, result2}
 }
 
-func (fake *CFAppRepository) FetchApp(arg1 client.Client, arg2 context.Context, arg3 string) (repositories.AppRecord, error) {
+func (fake *CFAppRepository) FetchApp(arg1 context.Context, arg2 client.Client, arg3 string) (repositories.AppRecord, error) {
 	fake.fetchAppMutex.Lock()
 	ret, specificReturn := fake.fetchAppReturnsOnCall[len(fake.fetchAppArgsForCall)]
 	fake.fetchAppArgsForCall = append(fake.fetchAppArgsForCall, struct {
-		arg1 client.Client
-		arg2 context.Context
+		arg1 context.Context
+		arg2 client.Client
 		arg3 string
 	}{arg1, arg2, arg3})
 	stub := fake.FetchAppStub
@@ -317,13 +317,13 @@ func (fake *CFAppRepository) FetchAppCallCount() int {
 	return len(fake.fetchAppArgsForCall)
 }
 
-func (fake *CFAppRepository) FetchAppCalls(stub func(client.Client, context.Context, string) (repositories.AppRecord, error)) {
+func (fake *CFAppRepository) FetchAppCalls(stub func(context.Context, client.Client, string) (repositories.AppRecord, error)) {
 	fake.fetchAppMutex.Lock()
 	defer fake.fetchAppMutex.Unlock()
 	fake.FetchAppStub = stub
 }
 
-func (fake *CFAppRepository) FetchAppArgsForCall(i int) (client.Client, context.Context, string) {
+func (fake *CFAppRepository) FetchAppArgsForCall(i int) (context.Context, client.Client, string) {
 	fake.fetchAppMutex.RLock()
 	defer fake.fetchAppMutex.RUnlock()
 	argsForCall := fake.fetchAppArgsForCall[i]
@@ -356,12 +356,12 @@ func (fake *CFAppRepository) FetchAppReturnsOnCall(i int, result1 repositories.A
 	}{result1, result2}
 }
 
-func (fake *CFAppRepository) FetchNamespace(arg1 client.Client, arg2 context.Context, arg3 string) (repositories.SpaceRecord, error) {
+func (fake *CFAppRepository) FetchNamespace(arg1 context.Context, arg2 client.Client, arg3 string) (repositories.SpaceRecord, error) {
 	fake.fetchNamespaceMutex.Lock()
 	ret, specificReturn := fake.fetchNamespaceReturnsOnCall[len(fake.fetchNamespaceArgsForCall)]
 	fake.fetchNamespaceArgsForCall = append(fake.fetchNamespaceArgsForCall, struct {
-		arg1 client.Client
-		arg2 context.Context
+		arg1 context.Context
+		arg2 client.Client
 		arg3 string
 	}{arg1, arg2, arg3})
 	stub := fake.FetchNamespaceStub
@@ -383,13 +383,13 @@ func (fake *CFAppRepository) FetchNamespaceCallCount() int {
 	return len(fake.fetchNamespaceArgsForCall)
 }
 
-func (fake *CFAppRepository) FetchNamespaceCalls(stub func(client.Client, context.Context, string) (repositories.SpaceRecord, error)) {
+func (fake *CFAppRepository) FetchNamespaceCalls(stub func(context.Context, client.Client, string) (repositories.SpaceRecord, error)) {
 	fake.fetchNamespaceMutex.Lock()
 	defer fake.fetchNamespaceMutex.Unlock()
 	fake.FetchNamespaceStub = stub
 }
 
-func (fake *CFAppRepository) FetchNamespaceArgsForCall(i int) (client.Client, context.Context, string) {
+func (fake *CFAppRepository) FetchNamespaceArgsForCall(i int) (context.Context, client.Client, string) {
 	fake.fetchNamespaceMutex.RLock()
 	defer fake.fetchNamespaceMutex.RUnlock()
 	argsForCall := fake.fetchNamespaceArgsForCall[i]

--- a/apis/fake/cfdomain_repository.go
+++ b/apis/fake/cfdomain_repository.go
@@ -2,6 +2,7 @@
 package fake
 
 import (
+	"context"
 	"sync"
 
 	"code.cloudfoundry.org/cf-k8s-api/apis"
@@ -10,11 +11,12 @@ import (
 )
 
 type CFDomainRepository struct {
-	FetchDomainStub        func(client.Client, string) (repositories.DomainRecord, error)
+	FetchDomainStub        func(context.Context, client.Client, string) (repositories.DomainRecord, error)
 	fetchDomainMutex       sync.RWMutex
 	fetchDomainArgsForCall []struct {
-		arg1 client.Client
-		arg2 string
+		arg1 context.Context
+		arg2 client.Client
+		arg3 string
 	}
 	fetchDomainReturns struct {
 		result1 repositories.DomainRecord
@@ -28,19 +30,20 @@ type CFDomainRepository struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *CFDomainRepository) FetchDomain(arg1 client.Client, arg2 string) (repositories.DomainRecord, error) {
+func (fake *CFDomainRepository) FetchDomain(arg1 context.Context, arg2 client.Client, arg3 string) (repositories.DomainRecord, error) {
 	fake.fetchDomainMutex.Lock()
 	ret, specificReturn := fake.fetchDomainReturnsOnCall[len(fake.fetchDomainArgsForCall)]
 	fake.fetchDomainArgsForCall = append(fake.fetchDomainArgsForCall, struct {
-		arg1 client.Client
-		arg2 string
-	}{arg1, arg2})
+		arg1 context.Context
+		arg2 client.Client
+		arg3 string
+	}{arg1, arg2, arg3})
 	stub := fake.FetchDomainStub
 	fakeReturns := fake.fetchDomainReturns
-	fake.recordInvocation("FetchDomain", []interface{}{arg1, arg2})
+	fake.recordInvocation("FetchDomain", []interface{}{arg1, arg2, arg3})
 	fake.fetchDomainMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -54,17 +57,17 @@ func (fake *CFDomainRepository) FetchDomainCallCount() int {
 	return len(fake.fetchDomainArgsForCall)
 }
 
-func (fake *CFDomainRepository) FetchDomainCalls(stub func(client.Client, string) (repositories.DomainRecord, error)) {
+func (fake *CFDomainRepository) FetchDomainCalls(stub func(context.Context, client.Client, string) (repositories.DomainRecord, error)) {
 	fake.fetchDomainMutex.Lock()
 	defer fake.fetchDomainMutex.Unlock()
 	fake.FetchDomainStub = stub
 }
 
-func (fake *CFDomainRepository) FetchDomainArgsForCall(i int) (client.Client, string) {
+func (fake *CFDomainRepository) FetchDomainArgsForCall(i int) (context.Context, client.Client, string) {
 	fake.fetchDomainMutex.RLock()
 	defer fake.fetchDomainMutex.RUnlock()
 	argsForCall := fake.fetchDomainArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *CFDomainRepository) FetchDomainReturns(result1 repositories.DomainRecord, result2 error) {

--- a/apis/fake/cfroute_repository.go
+++ b/apis/fake/cfroute_repository.go
@@ -2,6 +2,7 @@
 package fake
 
 import (
+	"context"
 	"sync"
 
 	"code.cloudfoundry.org/cf-k8s-api/apis"
@@ -10,11 +11,12 @@ import (
 )
 
 type CFRouteRepository struct {
-	FetchRouteStub        func(client.Client, string) (repositories.RouteRecord, error)
+	FetchRouteStub        func(context.Context, client.Client, string) (repositories.RouteRecord, error)
 	fetchRouteMutex       sync.RWMutex
 	fetchRouteArgsForCall []struct {
-		arg1 client.Client
-		arg2 string
+		arg1 context.Context
+		arg2 client.Client
+		arg3 string
 	}
 	fetchRouteReturns struct {
 		result1 repositories.RouteRecord
@@ -28,19 +30,20 @@ type CFRouteRepository struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *CFRouteRepository) FetchRoute(arg1 client.Client, arg2 string) (repositories.RouteRecord, error) {
+func (fake *CFRouteRepository) FetchRoute(arg1 context.Context, arg2 client.Client, arg3 string) (repositories.RouteRecord, error) {
 	fake.fetchRouteMutex.Lock()
 	ret, specificReturn := fake.fetchRouteReturnsOnCall[len(fake.fetchRouteArgsForCall)]
 	fake.fetchRouteArgsForCall = append(fake.fetchRouteArgsForCall, struct {
-		arg1 client.Client
-		arg2 string
-	}{arg1, arg2})
+		arg1 context.Context
+		arg2 client.Client
+		arg3 string
+	}{arg1, arg2, arg3})
 	stub := fake.FetchRouteStub
 	fakeReturns := fake.fetchRouteReturns
-	fake.recordInvocation("FetchRoute", []interface{}{arg1, arg2})
+	fake.recordInvocation("FetchRoute", []interface{}{arg1, arg2, arg3})
 	fake.fetchRouteMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -54,17 +57,17 @@ func (fake *CFRouteRepository) FetchRouteCallCount() int {
 	return len(fake.fetchRouteArgsForCall)
 }
 
-func (fake *CFRouteRepository) FetchRouteCalls(stub func(client.Client, string) (repositories.RouteRecord, error)) {
+func (fake *CFRouteRepository) FetchRouteCalls(stub func(context.Context, client.Client, string) (repositories.RouteRecord, error)) {
 	fake.fetchRouteMutex.Lock()
 	defer fake.fetchRouteMutex.Unlock()
 	fake.FetchRouteStub = stub
 }
 
-func (fake *CFRouteRepository) FetchRouteArgsForCall(i int) (client.Client, string) {
+func (fake *CFRouteRepository) FetchRouteArgsForCall(i int) (context.Context, client.Client, string) {
 	fake.fetchRouteMutex.RLock()
 	defer fake.fetchRouteMutex.RUnlock()
 	argsForCall := fake.fetchRouteArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *CFRouteRepository) FetchRouteReturns(result1 repositories.RouteRecord, result2 error) {

--- a/apis/route_handler_test.go
+++ b/apis/route_handler_test.go
@@ -138,11 +138,11 @@ func testRouteHandler(t *testing.T, when spec.G, it spec.S) {
 		// get this test passing eventually or move this test to an integration-style test
 		it.Pend("fetches the correct route and domain", func() {
 			g.Expect(routeRepo.FetchRouteCallCount()).To(Equal(1))
-			_, actualRouteGUID := routeRepo.FetchRouteArgsForCall(0)
+			_, _, actualRouteGUID := routeRepo.FetchRouteArgsForCall(0)
 			g.Expect(actualRouteGUID).To(Equal(expectedRouteGUID))
 
 			g.Expect(domainRepo.FetchDomainCallCount()).To(Equal(1))
-			_, actualDomainGUID := domainRepo.FetchDomainArgsForCall(0)
+			_, _, actualDomainGUID := domainRepo.FetchDomainArgsForCall(0)
 			g.Expect(actualDomainGUID).To(Equal(expectedDomainGUID))
 		})
 	})

--- a/repositories/app_repository.go
+++ b/repositories/app_repository.go
@@ -70,7 +70,7 @@ type AppEnvVarsRecord struct {
 	EnvironmentVariables map[string]string
 }
 
-func (f *AppRepo) FetchApp(client client.Client, ctx context.Context, appGUID string) (AppRecord, error) {
+func (f *AppRepo) FetchApp(ctx context.Context, client client.Client, appGUID string) (AppRecord, error) {
 	// TODO: Could look up namespace from guid => namespace cache to do Get
 	appList := &workloadsv1alpha1.CFAppList{}
 	err := client.List(ctx, appList)
@@ -92,7 +92,7 @@ func (f *AppRepo) getAppCR(client client.Client, ctx context.Context, appGUID st
 	return app, err
 }
 
-func (f *AppRepo) AppExists(client client.Client, ctx context.Context, appGUID string, namespace string) (bool, error) {
+func (f *AppRepo) AppExists(ctx context.Context, client client.Client, appGUID string, namespace string) (bool, error) {
 	_, err := f.getAppCR(client, ctx, appGUID, namespace)
 	if err != nil {
 		switch errtype := err.(type) {
@@ -108,7 +108,7 @@ func (f *AppRepo) AppExists(client client.Client, ctx context.Context, appGUID s
 	return true, nil
 }
 
-func (f *AppRepo) CreateApp(client client.Client, ctx context.Context, appRecord AppRecord) (AppRecord, error) {
+func (f *AppRepo) CreateApp(ctx context.Context, client client.Client, appRecord AppRecord) (AppRecord, error) {
 	cfApp := f.appRecordToCFApp(appRecord)
 	err := client.Create(ctx, &cfApp)
 	if err != nil {
@@ -186,7 +186,7 @@ func (f *AppRepo) filterAppsByName(apps []workloadsv1alpha1.CFApp, name string) 
 	return filtered
 }
 
-func (f *AppRepo) FetchNamespace(client client.Client, ctx context.Context, nsGUID string) (SpaceRecord, error) {
+func (f *AppRepo) FetchNamespace(ctx context.Context, client client.Client, nsGUID string) (SpaceRecord, error) {
 	namespace := &v1.Namespace{}
 	err := client.Get(ctx, types.NamespacedName{Name: nsGUID}, namespace)
 	if err != nil {
@@ -210,7 +210,7 @@ func (f *AppRepo) v1NamespaceToSpaceRecord(namespace *v1.Namespace) SpaceRecord 
 	}
 }
 
-func (f *AppRepo) CreateAppEnvironmentVariables(client client.Client, ctx context.Context, envVariables AppEnvVarsRecord) (AppEnvVarsRecord, error) {
+func (f *AppRepo) CreateAppEnvironmentVariables(ctx context.Context, client client.Client, envVariables AppEnvVarsRecord) (AppEnvVarsRecord, error) {
 	secretObj := f.appEnvVarsRecordToSecret(envVariables)
 	err := client.Create(ctx, &secretObj)
 	if err != nil {

--- a/repositories/app_repository_test.go
+++ b/repositories/app_repository_test.go
@@ -98,7 +98,7 @@ func testAppGet(t *testing.T, when spec.G, it spec.S) {
 			client, err := BuildClient(k8sConfig)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			app, err := appRepo.FetchApp(client, testCtx, app2GUID)
+			app, err := appRepo.FetchApp(testCtx, client, app2GUID)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(app.GUID).To(Equal(app2GUID))
 			g.Expect(app.Name).To(Equal("test-app2"))
@@ -179,7 +179,7 @@ func testAppGet(t *testing.T, when spec.G, it spec.S) {
 			client, err := BuildClient(k8sConfig)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			_, err = appRepo.FetchApp(client, testCtx, testAppGUID)
+			_, err = appRepo.FetchApp(testCtx, client, testAppGUID)
 			g.Expect(err).To(HaveOccurred())
 			g.Expect(err).To(MatchError("duplicate apps exist"))
 		})
@@ -191,7 +191,7 @@ func testAppGet(t *testing.T, when spec.G, it spec.S) {
 			client, err := BuildClient(k8sConfig)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			_, err = appRepo.FetchApp(client, testCtx, "i don't exist")
+			_, err = appRepo.FetchApp(testCtx, client, "i don't exist")
 			g.Expect(err).To(HaveOccurred())
 			g.Expect(err).To(MatchError("not found"))
 		})
@@ -280,7 +280,7 @@ func testAppCreate(t *testing.T, when spec.G, it spec.S) {
 				appRepo := AppRepo{}
 				client, err := BuildClient(k8sConfig)
 
-				_, err = appRepo.FetchNamespace(client, testCtx, "some-guid")
+				_, err = appRepo.FetchNamespace(testCtx, client, "some-guid")
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError("Invalid space. Ensure that the space exists and you have access to it."))
 			})
@@ -301,13 +301,13 @@ func testAppCreate(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("returns false when checking if the App Exists", func() {
-				exists, err := appRepo.AppExists(client, testCtx, testAppGUID, defaultNamespace)
+				exists, err := appRepo.AppExists(testCtx, client, testAppGUID, defaultNamespace)
 				g.Expect(exists).To(BeFalse())
 				g.Expect(err).NotTo(HaveOccurred())
 			})
 
 			it("should create a new app CR successfully", func() {
-				createdAppRecord, err := appRepo.CreateApp(client, testCtx, appRecord)
+				createdAppRecord, err := appRepo.CreateApp(testCtx, client, appRecord)
 				g.Expect(err).To(BeNil())
 				g.Expect(createdAppRecord).NotTo(BeNil())
 
@@ -333,7 +333,7 @@ func testAppCreate(t *testing.T, when spec.G, it spec.S) {
 					beforeCreationTime = time.Now().UTC().AddDate(0, 0, -1)
 
 					var err error
-					createdAppRecord, err = appRepo.CreateApp(client, beforeCtx, appRecord)
+					createdAppRecord, err = appRepo.CreateApp(beforeCtx, client, appRecord)
 					g.Expect(err).To(BeNil())
 				})
 				it.After(func() {
@@ -392,17 +392,17 @@ func testAppCreate(t *testing.T, when spec.G, it spec.S) {
 
 			it("should eventually return true when AppExists is called", func() {
 				g.Eventually(func() bool {
-					exists, _ := appRepo.AppExists(client, testCtx, testAppGUID, defaultNamespace)
+					exists, _ := appRepo.AppExists(testCtx, client, testAppGUID, defaultNamespace)
 					return exists
 				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue())
-				exists, err := appRepo.AppExists(client, testCtx, testAppGUID, defaultNamespace)
+				exists, err := appRepo.AppExists(testCtx, client, testAppGUID, defaultNamespace)
 				g.Expect(exists).To(BeTrue())
 				g.Expect(err).NotTo(HaveOccurred())
 			})
 
 			it("should error when trying to create the same app again", func() {
 				appRecord := intializeAppRecord(testAppName, testAppGUID, defaultNamespace)
-				createdAppRecord, err := appRepo.CreateApp(client, testCtx, appRecord)
+				createdAppRecord, err := appRepo.CreateApp(testCtx, client, appRecord)
 				g.Expect(err).NotTo(BeNil())
 				g.Expect(createdAppRecord).To(Equal(emptyAppRecord))
 			})
@@ -446,7 +446,7 @@ func testEnvSecretCreate(t *testing.T, when spec.G, it spec.S) {
 				EnvironmentVariables: map[string]string{"foo": "foo", "bar": "bar"},
 			}
 
-			returnedAppEnvVarsRecord, returnedErr = appRepo.CreateAppEnvironmentVariables(client, beforeCtx, testAppEnvSecret)
+			returnedAppEnvVarsRecord, returnedErr = appRepo.CreateAppEnvironmentVariables(beforeCtx, client, testAppEnvSecret)
 
 		})
 
@@ -508,7 +508,7 @@ func testEnvSecretCreate(t *testing.T, when spec.G, it spec.S) {
 			testCtx := context.Background()
 			testAppEnvSecret.EnvironmentVariables = map[string]string{"foo": "foo", "bar": "bar"}
 
-			returnedUpdatedAppEnvVarsRecord, returnedUpdatedErr := appRepo.CreateAppEnvironmentVariables(client, testCtx, testAppEnvSecret)
+			returnedUpdatedAppEnvVarsRecord, returnedUpdatedErr := appRepo.CreateAppEnvironmentVariables(testCtx, client, testAppEnvSecret)
 			g.Expect(returnedUpdatedErr).ToNot(BeNil())
 			g.Expect(returnedUpdatedAppEnvVarsRecord).To(Equal(AppEnvVarsRecord{}))
 		})

--- a/repositories/domain_repository.go
+++ b/repositories/domain_repository.go
@@ -21,9 +21,9 @@ type DomainRecord struct {
 	UpdatedAt string
 }
 
-func (f *DomainRepo) FetchDomain(client client.Client, domainGUID string) (DomainRecord, error) {
+func (f *DomainRepo) FetchDomain(ctx context.Context, client client.Client, domainGUID string) (DomainRecord, error) {
 	cfDomainList := &networkingv1alpha1.CFDomainList{}
-	err := client.List(context.Background(), cfDomainList)
+	err := client.List(ctx, cfDomainList)
 
 	if err != nil {
 		return DomainRecord{}, err

--- a/repositories/route_repository.go
+++ b/repositories/route_repository.go
@@ -34,10 +34,10 @@ type RouteRecord struct {
 	UpdatedAt    string
 }
 
-func (f *RouteRepo) FetchRoute(client client.Client, routeGUID string) (RouteRecord, error) {
+func (f *RouteRepo) FetchRoute(ctx context.Context, client client.Client, routeGUID string) (RouteRecord, error) {
 	// TODO: Could look up namespace from guid => namespace cache to do Get
 	cfRouteList := &networkingv1alpha1.CFRouteList{}
-	err := client.List(context.Background(), cfRouteList)
+	err := client.List(ctx, cfRouteList)
 
 	if err != nil {
 		return RouteRecord{}, err


### PR DESCRIPTION
## Is there a related GitHub Issue?
No issue, just a verbally suggested team chore.

## What is this change about?
As title suggests, refactor interfaces that use context.Context to make it the first argument. For http serve consumers of those interfaces, pass request context to that argument.

## Does this PR introduce a breaking change?
No, the change is an in-place refactor.

## Acceptance Steps
Tests continue to pass, standard get requests on apps and routes continue to succeed.

## Tag your pair, your PM, and/or team
pair @davewalter and cc suggester @matt-royal 
