### PR TITLE
Implemented Resource Matching endpoint

### DIFF
--- a/apis/resource_matches_handler.go
+++ b/apis/resource_matches_handler.go
@@ -1,0 +1,15 @@
+package apis
+
+import (
+	"net/http"
+)
+
+type ResourceMatchesHandler struct {
+	ServerURL string
+}
+
+func (h *ResourceMatchesHandler) ResourceMatchesPostHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	w.Write([]byte(`{"resources":[]}`))
+}

--- a/apis/resource_matches_handler_test.go
+++ b/apis/resource_matches_handler_test.go
@@ -1,0 +1,61 @@
+package apis_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	. "code.cloudfoundry.org/cf-k8s-api/apis"
+
+	. "github.com/onsi/gomega"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+)
+
+func TestResourceMatches(t *testing.T) {
+	spec.Run(t, "ResourceMatchesHandler", testResourceMatchesHandler, spec.Report(report.Terminal{}))
+}
+
+func testResourceMatchesHandler(t *testing.T, when spec.G, it spec.S) {
+	g := NewWithT(t)
+
+	var (
+		rr         *httptest.ResponseRecorder
+		apiHandler *ResourceMatchesHandler
+	)
+
+	makePostRequest := func(body string) {
+		req, err := http.NewRequest("POST", "unused-path", strings.NewReader(body))
+		g.Expect(err).NotTo(HaveOccurred())
+
+		handler := http.HandlerFunc(apiHandler.ResourceMatchesPostHandler)
+		handler.ServeHTTP(rr, req)
+	}
+
+	it.Before(func() {
+		rr = httptest.NewRecorder()
+		apiHandler = &ResourceMatchesHandler{}
+	})
+
+	when("ResourceMatchesHandler is called", func() {
+		it.Before(func() {
+			makePostRequest(`{}`)
+		})
+
+		it("returns status 201 Created", func() {
+			g.Expect(rr.Code).Should(Equal(http.StatusCreated), "Matching HTTP response code:")
+		})
+
+		it("returns Content-Type as JSON in header", func() {
+			contentTypeHeader := rr.Header().Get("Content-Type")
+			g.Expect(contentTypeHeader).Should(Equal(jsonHeader), "Matching Content-Type header:")
+		})
+
+		it("returns a CF API formatted Error response", func() {
+			g.Expect(rr.Body.String()).Should(MatchJSON(`{
+				"resources": []
+			  }`), "Response body matches response:")
+		})
+	})
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,17 +6,31 @@
 
 ### Root
 
-Docs: https://v3-apidocs.cloudfoundry.org/version/3.102.0/index.html#root
+Docs: https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#root
 
 | Resource | Endpoint |
 |--|--|
 | Global API Root | GET / |
 | V3 API Root | GET /v3 |
 
+### Resource Matches
+
+Docs: https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#resource-matches
+
+| Resource | Endpoint |
+|--|--|
+| Create a Resource Match | POST /v3/resource_matches |
+
+#### [Create a Resource Match](https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#create-a-resource-match)
+```bash
+curl "http://localhost:9000/v3/resource_matches" \
+  -X POST \
+  -d '{}'
+```
 
 ### Apps
 
-Docs: https://v3-apidocs.cloudfoundry.org/version/3.102.0/index.html#apps
+Docs: https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#apps
 
 | Resource | Endpoint |
 |--|--|

--- a/main.go
+++ b/main.go
@@ -52,6 +52,9 @@ func main() {
 	apiRootHandler := &apis.RootHandler{
 		ServerURL: config.ServerURL,
 	}
+	resourceMatchesHandler := &apis.ResourceMatchesHandler{
+		ServerURL: config.ServerURL,
+	}
 	appHandler := &apis.AppHandler{
 		ServerURL:   config.ServerURL,
 		AppRepo:     &repositories.AppRepo{},
@@ -80,12 +83,13 @@ func main() {
 	// create API routes
 	apiRoutes := routes.APIRoutes{
 		//add API routes to handler
-		RootV3Handler:        apiRootV3Handler.RootV3GetHandler,
-		RootHandler:          apiRootHandler.RootGetHandler,
-		AppCreateHandler:     appHandler.AppCreateHandler,
-		AppGetHandler:        appHandler.AppGetHandler,
-		RouteGetHandler:      routeHandler.RouteGetHandler,
-		PackageCreateHandler: packageHandler.PackageCreateHandler,
+		RootV3Handler:          apiRootV3Handler.RootV3GetHandler,
+		RootHandler:            apiRootHandler.RootGetHandler,
+		ResourceMatchesHandler: resourceMatchesHandler.ResourceMatchesPostHandler,
+		AppCreateHandler:       appHandler.AppCreateHandler,
+		AppGetHandler:          appHandler.AppGetHandler,
+		RouteGetHandler:        routeHandler.RouteGetHandler,
+		PackageCreateHandler:   packageHandler.PackageCreateHandler,
 	}
 	// Call RegisterRoutes to register all the routes in APIRoutes
 	apiRoutes.RegisterRoutes(router)

--- a/repositories/package_repository_test.go
+++ b/repositories/package_repository_test.go
@@ -21,7 +21,7 @@ import (
 var _ = SuiteDescribe("Package Repository CreatePackage", func(t *testing.T, when spec.G, it spec.S) {
 	g := NewWithT(t)
 
-	when.Focus("on the happy path", func() {
+	when("on the happy path", func() {
 		var (
 			packageRepo   *PackageRepo
 			client        client.Client

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -9,29 +9,32 @@ import (
 // Just contains the CF API Routes and maps them to handler functions
 
 const (
-	RootGetEndpoint       = "/"
-	RootV3GetEndpoint     = "/v3"
-	AppCreateEndpoint     = "/v3/apps"
-	AppGetEndpoint        = "/v3/apps/{guid}"
-	RouteGetEndpoint      = "/v3/routes/{guid}"
-	PackageCreateEndpoint = "/v3/packages"
+	RootGetEndpoint         = "/"
+	RootV3GetEndpoint       = "/v3"
+	ResourceMatchesEndpoint = "/v3/resource_matches"
+	AppCreateEndpoint       = "/v3/apps"
+	AppGetEndpoint          = "/v3/apps/{guid}"
+	RouteGetEndpoint        = "/v3/routes/{guid}"
+	PackageCreateEndpoint   = "/v3/packages"
 )
 
 type httpHandlerFunction func(w http.ResponseWriter, r *http.Request)
 
 type APIRoutes struct {
-	RootV3Handler        httpHandlerFunction
-	RootHandler          httpHandlerFunction
-	AppCreateHandler     httpHandlerFunction
-	AppGetHandler        httpHandlerFunction
-	RouteGetHandler      httpHandlerFunction
-	PackageCreateHandler httpHandlerFunction
+	RootV3Handler          httpHandlerFunction
+	RootHandler            httpHandlerFunction
+	ResourceMatchesHandler httpHandlerFunction
+	AppCreateHandler       httpHandlerFunction
+	AppGetHandler          httpHandlerFunction
+	RouteGetHandler        httpHandlerFunction
+	PackageCreateHandler   httpHandlerFunction
 }
 
 func (a *APIRoutes) RegisterRoutes(router *mux.Router) {
 	// Is this a useful check?
 	if a.RootV3Handler == nil ||
 		a.RootHandler == nil ||
+		a.ResourceMatchesHandler == nil ||
 		a.AppGetHandler == nil ||
 		a.AppCreateHandler == nil ||
 		a.RouteGetHandler == nil ||
@@ -41,6 +44,7 @@ func (a *APIRoutes) RegisterRoutes(router *mux.Router) {
 
 	router.HandleFunc(RootGetEndpoint, a.RootHandler).Methods("GET")
 	router.HandleFunc(RootV3GetEndpoint, a.RootV3Handler).Methods("GET")
+	router.HandleFunc(ResourceMatchesEndpoint, a.ResourceMatchesHandler).Methods("POST")
 	router.HandleFunc(AppCreateEndpoint, a.AppCreateHandler).Methods("POST")
 	router.HandleFunc(AppGetEndpoint, a.AppGetHandler).Methods("GET")
 	router.HandleFunc(RouteGetEndpoint, a.RouteGetHandler).Methods("GET")

--- a/routes/routes_test.go
+++ b/routes/routes_test.go
@@ -25,12 +25,13 @@ func initializeAPIRoutes() *routes.APIRoutes {
 	emptyHandlerFunc := func(w http.ResponseWriter, r *http.Request) {}
 
 	return &routes.APIRoutes{
-		RootV3Handler:        emptyHandlerFunc,
-		RootHandler:          emptyHandlerFunc,
-		AppCreateHandler:     emptyHandlerFunc,
-		AppGetHandler:        emptyHandlerFunc,
-		PackageCreateHandler: emptyHandlerFunc,
-		RouteGetHandler:      emptyHandlerFunc,
+		RootV3Handler:          emptyHandlerFunc,
+		RootHandler:            emptyHandlerFunc,
+		ResourceMatchesHandler: emptyHandlerFunc,
+		AppCreateHandler:       emptyHandlerFunc,
+		AppGetHandler:          emptyHandlerFunc,
+		PackageCreateHandler:   emptyHandlerFunc,
+		RouteGetHandler:        emptyHandlerFunc,
 	}
 }
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
#66 

## What is this change about?
Implemented naive Resource Matches endpoint for compatibility with CF CLI.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
* Run API against a Kubernetes cluster
* `curl -v "http://localhost:9000/v3/resource_matches" -X POST -H "Content-Type: application/json" -d '{}'`

## Tag your pair, your PM, and/or team
@gnovv
