### PR TITLE
Rename the message package and types to payload(s)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN go mod download
 COPY main.go main.go
 COPY apis/ apis/
 COPY config/ config/
-COPY message/ message/
+COPY payloads/ payloads/
 COPY presenter/ presenter/
 COPY repositories/ repositories/
 

--- a/apis/fake/cfpackage_repository.go
+++ b/apis/fake/cfpackage_repository.go
@@ -11,12 +11,12 @@ import (
 )
 
 type CFPackageRepository struct {
-	CreatePackageStub        func(context.Context, client.Client, repositories.PackageCreate) (repositories.PackageRecord, error)
+	CreatePackageStub        func(context.Context, client.Client, repositories.PackageCreateMessage) (repositories.PackageRecord, error)
 	createPackageMutex       sync.RWMutex
 	createPackageArgsForCall []struct {
 		arg1 context.Context
 		arg2 client.Client
-		arg3 repositories.PackageCreate
+		arg3 repositories.PackageCreateMessage
 	}
 	createPackageReturns struct {
 		result1 repositories.PackageRecord
@@ -45,13 +45,13 @@ type CFPackageRepository struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *CFPackageRepository) CreatePackage(arg1 context.Context, arg2 client.Client, arg3 repositories.PackageCreate) (repositories.PackageRecord, error) {
+func (fake *CFPackageRepository) CreatePackage(arg1 context.Context, arg2 client.Client, arg3 repositories.PackageCreateMessage) (repositories.PackageRecord, error) {
 	fake.createPackageMutex.Lock()
 	ret, specificReturn := fake.createPackageReturnsOnCall[len(fake.createPackageArgsForCall)]
 	fake.createPackageArgsForCall = append(fake.createPackageArgsForCall, struct {
 		arg1 context.Context
 		arg2 client.Client
-		arg3 repositories.PackageCreate
+		arg3 repositories.PackageCreateMessage
 	}{arg1, arg2, arg3})
 	stub := fake.CreatePackageStub
 	fakeReturns := fake.createPackageReturns
@@ -72,13 +72,13 @@ func (fake *CFPackageRepository) CreatePackageCallCount() int {
 	return len(fake.createPackageArgsForCall)
 }
 
-func (fake *CFPackageRepository) CreatePackageCalls(stub func(context.Context, client.Client, repositories.PackageCreate) (repositories.PackageRecord, error)) {
+func (fake *CFPackageRepository) CreatePackageCalls(stub func(context.Context, client.Client, repositories.PackageCreateMessage) (repositories.PackageRecord, error)) {
 	fake.createPackageMutex.Lock()
 	defer fake.createPackageMutex.Unlock()
 	fake.CreatePackageStub = stub
 }
 
-func (fake *CFPackageRepository) CreatePackageArgsForCall(i int) (context.Context, client.Client, repositories.PackageCreate) {
+func (fake *CFPackageRepository) CreatePackageArgsForCall(i int) (context.Context, client.Client, repositories.PackageCreateMessage) {
 	fake.createPackageMutex.RLock()
 	defer fake.createPackageMutex.RUnlock()
 	argsForCall := fake.createPackageArgsForCall[i]

--- a/apis/package_handler_test.go
+++ b/apis/package_handler_test.go
@@ -123,7 +123,7 @@ func testPackageCreateHandler(t *testing.T, when spec.G, it spec.S) {
 		it("creates a CFPackage", func() {
 			g.Expect(packageRepo.CreatePackageCallCount()).To(Equal(1))
 			_, _, actualCreate := packageRepo.CreatePackageArgsForCall(0)
-			g.Expect(actualCreate).To(Equal(repositories.PackageCreate{
+			g.Expect(actualCreate).To(Equal(repositories.PackageCreateMessage{
 				Type:      "bits",
 				AppGUID:   appGUID,
 				SpaceGUID: spaceGUID,

--- a/apis/route_handler.go
+++ b/apis/route_handler.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"net/http"
 
-	"code.cloudfoundry.org/cf-k8s-api/message"
+	"code.cloudfoundry.org/cf-k8s-api/payloads"
 	"code.cloudfoundry.org/cf-k8s-api/presenter"
 	"code.cloudfoundry.org/cf-k8s-api/repositories"
 
@@ -107,7 +107,7 @@ func (h *RouteHandler) RouteCreateHandler(w http.ResponseWriter, r *http.Request
 	ctx := r.Context()
 	w.Header().Set("Content-Type", "application/json")
 
-	var routeCreateMessage message.RouteCreateMessage
+	var routeCreateMessage payloads.RouteCreate
 	rme := DecodePayload(r, &routeCreateMessage)
 	if rme != nil {
 		writeErrorResponse(w, rme)
@@ -155,7 +155,7 @@ func (h *RouteHandler) RouteCreateHandler(w http.ResponseWriter, r *http.Request
 
 	routeGUID := uuid.New().String()
 
-	createRouteRecord := message.RouteCreateMessageToRouteRecord(routeCreateMessage)
+	createRouteRecord := routeCreateMessage.ToRecord()
 	createRouteRecord.GUID = routeGUID
 
 	responseRouteRecord, err := h.RouteRepo.CreateRoute(ctx, client, createRouteRecord)

--- a/payloads/app.go
+++ b/payloads/app.go
@@ -1,4 +1,4 @@
-package message
+package payloads
 
 import (
 	"code.cloudfoundry.org/cf-k8s-api/repositories"
@@ -10,7 +10,7 @@ var (
 	defaultLifecycleStack = "cflinuxfs3"
 )
 
-type AppCreateMessage struct {
+type AppCreate struct {
 	Name                 string            `json:"name" validate:"required"`
 	EnvironmentVariables map[string]string `json:"environment_variables"`
 	Relationships        AppRelationships  `json:"relationships" validate:"required"`
@@ -22,24 +22,24 @@ type AppRelationships struct {
 	Space Relationship `json:"space" validate:"required"`
 }
 
-func AppCreateMessageToAppRecord(requestApp AppCreateMessage) repositories.AppRecord {
+func (p AppCreate) ToRecord() repositories.AppRecord {
 	lifecycleBlock := repositories.Lifecycle{
 		Type: defaultLifecycleType,
 		Data: repositories.LifecycleData{
 			Stack: defaultLifecycleStack,
 		},
 	}
-	if requestApp.Lifecycle != nil {
-		lifecycleBlock.Data.Stack = requestApp.Lifecycle.Data.Stack
-		lifecycleBlock.Data.Buildpacks = requestApp.Lifecycle.Data.Buildpacks
+	if p.Lifecycle != nil {
+		lifecycleBlock.Data.Stack = p.Lifecycle.Data.Stack
+		lifecycleBlock.Data.Buildpacks = p.Lifecycle.Data.Buildpacks
 	}
 
 	return repositories.AppRecord{
-		Name:        requestApp.Name,
+		Name:        p.Name,
 		GUID:        "",
-		SpaceGUID:   requestApp.Relationships.Space.Data.GUID,
-		Labels:      requestApp.Metadata.Labels,
-		Annotations: requestApp.Metadata.Annotations,
+		SpaceGUID:   p.Relationships.Space.Data.GUID,
+		Labels:      p.Metadata.Labels,
+		Annotations: p.Metadata.Annotations,
 		State:       repositories.StoppedState,
 		Lifecycle:   lifecycleBlock,
 		CreatedAt:   "",

--- a/payloads/package.go
+++ b/payloads/package.go
@@ -1,8 +1,8 @@
-package message
+package payloads
 
 import "code.cloudfoundry.org/cf-k8s-api/repositories"
 
-type CreatePackageMessage struct {
+type PackageCreate struct {
 	Type          string                `json:"type" validate:"required,oneof='bits'"`
 	Relationships *PackageRelationships `json:"relationships" validate:"required"`
 }
@@ -11,8 +11,8 @@ type PackageRelationships struct {
 	App *Relationship `json:"app" validate:"required"`
 }
 
-func (m CreatePackageMessage) ToRecord(spaceGUID string) repositories.PackageCreate {
-	return repositories.PackageCreate{
+func (m PackageCreate) ToMessage(spaceGUID string) repositories.PackageCreateMessage {
+	return repositories.PackageCreateMessage{
 		Type:      m.Type,
 		AppGUID:   m.Relationships.App.Data.GUID,
 		SpaceGUID: spaceGUID,

--- a/payloads/route.go
+++ b/payloads/route.go
@@ -1,4 +1,4 @@
-package message
+package payloads
 
 import (
 	"code.cloudfoundry.org/cf-k8s-api/repositories"
@@ -10,7 +10,7 @@ var (
 // defaultLifecycleStack = "cflinuxfs3"
 )
 
-type RouteCreateMessage struct {
+type RouteCreate struct {
 	Host          string             `json:"host" validate:"required"` // TODO: Remove required flag when we support private domains
 	Path          string             `json:"path"`
 	Relationships RouteRelationships `json:"relationships" validate:"required"`
@@ -22,17 +22,17 @@ type RouteRelationships struct {
 	Space  Relationship `json:"space" validate:"required"`
 }
 
-func RouteCreateMessageToRouteRecord(requestRoute RouteCreateMessage) repositories.RouteRecord {
+func (p RouteCreate) ToRecord() repositories.RouteRecord {
 	return repositories.RouteRecord{
 		GUID:      "",
-		Host:      requestRoute.Host,
-		Path:      requestRoute.Path,
-		SpaceGUID: requestRoute.Relationships.Space.Data.GUID,
+		Host:      p.Host,
+		Path:      p.Path,
+		SpaceGUID: p.Relationships.Space.Data.GUID,
 		DomainRef: repositories.DomainRecord{
-			GUID: requestRoute.Relationships.Domain.Data.GUID,
+			GUID: p.Relationships.Domain.Data.GUID,
 		},
-		Labels:      requestRoute.Metadata.Labels,
-		Annotations: requestRoute.Metadata.Annotations,
+		Labels:      p.Metadata.Labels,
+		Annotations: p.Metadata.Annotations,
 		CreatedAt:   "",
 		UpdatedAt:   "",
 	}

--- a/payloads/shared.go
+++ b/payloads/shared.go
@@ -1,4 +1,4 @@
-package message
+package payloads
 
 type Lifecycle struct {
 	Type string        `json:"type" validate:"required"`

--- a/repositories/package_repository.go
+++ b/repositories/package_repository.go
@@ -14,7 +14,7 @@ const (
 	kind = "CFPackage"
 )
 
-type PackageCreate struct {
+type PackageCreateMessage struct {
 	Type      string
 	AppGUID   string
 	SpaceGUID string
@@ -31,8 +31,8 @@ type PackageRecord struct {
 
 type PackageRepo struct{}
 
-func (r *PackageRepo) CreatePackage(ctx context.Context, client client.Client, cp PackageCreate) (PackageRecord, error) {
-	cfPackage := r.packageCreateToCFPackage(cp)
+func (r *PackageRepo) CreatePackage(ctx context.Context, client client.Client, message PackageCreateMessage) (PackageRecord, error) {
+	cfPackage := r.packageCreateToCFPackage(message)
 	err := client.Create(ctx, &cfPackage)
 	if err != nil {
 		return PackageRecord{}, err
@@ -52,7 +52,7 @@ func (r *PackageRepo) FetchPackage(ctx context.Context, client client.Client, gu
 	return r.returnPackage(matches)
 }
 
-func (r *PackageRepo) packageCreateToCFPackage(cp PackageCreate) workloadsv1alpha1.CFPackage {
+func (r *PackageRepo) packageCreateToCFPackage(message PackageCreateMessage) workloadsv1alpha1.CFPackage {
 	guid := uuid.New().String()
 	return workloadsv1alpha1.CFPackage{
 		TypeMeta: metav1.TypeMeta{
@@ -61,12 +61,12 @@ func (r *PackageRepo) packageCreateToCFPackage(cp PackageCreate) workloadsv1alph
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      guid,
-			Namespace: cp.SpaceGUID,
+			Namespace: message.SpaceGUID,
 		},
 		Spec: workloadsv1alpha1.CFPackageSpec{
-			Type: workloadsv1alpha1.PackageType(cp.Type),
+			Type: workloadsv1alpha1.PackageType(message.Type),
 			AppRef: workloadsv1alpha1.ResourceReference{
-				Name: cp.AppGUID,
+				Name: message.AppGUID,
 			},
 		},
 	}

--- a/repositories/package_repository_test.go
+++ b/repositories/package_repository_test.go
@@ -28,7 +28,7 @@ func testCreatePackage(t *testing.T, when spec.G, it spec.S) {
 	var (
 		packageRepo   *PackageRepo
 		client        client.Client
-		packageCreate PackageCreate
+		packageCreate PackageCreateMessage
 		ctx           context.Context
 	)
 
@@ -44,7 +44,7 @@ func testCreatePackage(t *testing.T, when spec.G, it spec.S) {
 		client, err = BuildClient(k8sConfig)
 		g.Expect(err).NotTo(HaveOccurred())
 
-		packageCreate = PackageCreate{
+		packageCreate = PackageCreateMessage{
 			Type:      "bits",
 			AppGUID:   appGUID,
 			SpaceGUID: spaceGUID,


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Objects like the former repositories.CreatePackage are now "messages"
(e.g. repositories.PackageCreateMessage)

Also move payload.AppCreateMessageToAppRecord() to payload.AppCreate.ToRecord()

## Does this PR introduce a breaking change?
No

## Acceptance Steps
None (this is a pure chore)

## Tag your pair, your PM, and/or team
@akrishna90 