### PR TITLE
Fix implementation of FetchDomain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,8 @@ RUN go mod download
 COPY main.go main.go
 COPY apis/ apis/
 COPY config/ config/
-COPY routes/ routes/
-COPY presenter/ presenter/
 COPY message/ message/
+COPY presenter/ presenter/
 COPY repositories/ repositories/
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o cfapi main.go

--- a/repositories/domain_repository_test.go
+++ b/repositories/domain_repository_test.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"testing"
 
-	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/networking/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	. "code.cloudfoundry.org/cf-k8s-api/repositories"
+	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/networking/v1alpha1"
 
 	. "github.com/onsi/gomega"
 	"github.com/sclevine/spec"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = SuiteDescribe("Domain API Shim", func(t *testing.T, when spec.G, it spec.S) {
@@ -80,7 +79,7 @@ var _ = SuiteDescribe("Domain API Shim", func(t *testing.T, when spec.G, it spec
 			g.Expect(err).ToNot(HaveOccurred())
 
 			_, err = domainRepo.FetchDomain(testCtx, client, "non-existent-domain-guid")
-			g.Expect(err).To(MatchError("not found"))
+			g.Expect(err).To(MatchError("Resource not found or permission denied."))
 		})
 	})
 })


### PR DESCRIPTION
## Is there a related GitHub Issue?
#38

## What is this change about?
This PR fixes the implementation of FetchDomain to use `client.Get` instead of filtering a list, and to return the correct typed error when the domain is not found.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #38 

## Tag your pair, your PM, and/or team
@acosta11 