### PR TITLE
Introduce `"cf_on_k8s": true` into the `/` response

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,10 @@ func main() {
 
 	handlers := []APIHandler{
 		apis.NewRootV3Handler(config.ServerURL),
-		apis.NewRootHandler(config.ServerURL),
+		apis.NewRootHandler(
+			ctrl.Log.WithName("RootHandler"),
+			config.ServerURL,
+		),
 		apis.NewResourceMatchesHandler(config.ServerURL),
 		apis.NewAppHandler(
 			ctrl.Log.WithName("AppHandler"),

--- a/presenter/root.go
+++ b/presenter/root.go
@@ -1,0 +1,37 @@
+package presenter
+
+type APILink struct {
+	Link
+	Meta APILinkMeta `json:"meta"`
+}
+
+type APILinkMeta struct {
+	Version string `json:"version"`
+}
+
+type RootResponse struct {
+	Links   map[string]*APILink `json:"links"`
+	CFOnK8s bool                `json:"cf_on_k8s"`
+}
+
+func GetRootResponse(serverURL string) RootResponse {
+	return RootResponse{
+		Links: map[string]*APILink{
+			"self":                {Link: Link{HREF: serverURL}},
+			"bits_service":        nil,
+			"cloud_controller_v2": nil,
+			"cloud_controller_v3": {Link: Link{HREF: serverURL + "/v3"}, Meta: APILinkMeta{Version: "3.90.0"}},
+			"network_policy_v0":   nil,
+			"network_policy_v1":   nil,
+			"login":               nil,
+			"uaa":                 nil,
+			"credhub":             nil,
+			"routing":             nil,
+			"logging":             nil,
+			"log_cache":           nil,
+			"log_stream":          nil,
+			"app_ssh":             nil,
+		},
+		CFOnK8s: true,
+	}
+}


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/cf-k8s-api/issues/10

## What is this change about?
Introduce a `cf_on_k8s` property into the `GET /` response which is always true in CF-on-K8S API. This property will be processed by the CLI to figure out that it is talking to CF-on-K8s rather than CF-on-VMs. See https://github.com/eirini-forks/cli/pull/1 for details.

The change is compatible with the CF-on-VMs CC API as the absence of that field defaults to `false` on the CLI side, i.e. CLI would know that it talks to CF-on-VMs without actually changing the CC API there. 


## Does this PR introduce a breaking change?
No

## Acceptance Steps
1. Start the API
2. `curl localhost:9000`
3. See `"cf_on_k8s": true` in the response body

## Tag your pair
@georgethebeatle 
