### PR TITLE
Introduce contructors for rest handlers

### DIFF
--- a/apis/app_handler_test.go
+++ b/apis/app_handler_test.go
@@ -74,13 +74,13 @@ func testAppGetHandler(t *testing.T, when spec.G, it spec.S) {
 		router = mux.NewRouter()
 		clientBuilder := new(fake.ClientBuilder)
 
-		apiHandler := &AppHandler{
-			ServerURL:   defaultServerURL,
-			AppRepo:     appRepo,
-			Logger:      logf.Log.WithName(testAppHandlerLoggerName),
-			K8sConfig:   &rest.Config{},
-			BuildClient: clientBuilder.Spy,
-		}
+		apiHandler := NewAppHandler(
+			logf.Log.WithName(testAppHandlerLoggerName),
+			defaultServerURL,
+			appRepo,
+			clientBuilder.Spy,
+			&rest.Config{},
+		)
 		apiHandler.RegisterRoutes(router)
 	})
 
@@ -221,13 +221,13 @@ func testAppCreateHandler(t *testing.T, when spec.G, it spec.S) {
 		router = mux.NewRouter()
 
 		appRepo = new(fake.CFAppRepository)
-		apiHandler := &AppHandler{
-			ServerURL:   defaultServerURL,
-			AppRepo:     appRepo,
-			Logger:      logf.Log.WithName(testAppHandlerLoggerName),
-			K8sConfig:   &rest.Config{},
-			BuildClient: new(fake.ClientBuilder).Spy,
-		}
+		apiHandler := NewAppHandler(
+			logf.Log.WithName(testAppHandlerLoggerName),
+			defaultServerURL,
+			appRepo,
+			new(fake.ClientBuilder).Spy,
+			&rest.Config{},
+		)
 		apiHandler.RegisterRoutes(router)
 	})
 
@@ -680,9 +680,7 @@ func testAppCreateHandler(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("a POST test app request is sent with metadata labels", func() {
-			var (
-				testLabels map[string]string
-			)
+			var testLabels map[string]string
 
 			it.Before(func() {
 				testLabels = map[string]string{"foo": "foo", "bar": "bar"}
@@ -699,9 +697,7 @@ func testAppCreateHandler(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("a POST test app request is sent with metadata annotations", func() {
-			var (
-				testAnnotations map[string]string
-			)
+			var testAnnotations map[string]string
 
 			it.Before(func() {
 				testAnnotations = map[string]string{"foo": "foo", "bar": "bar"}
@@ -795,13 +791,13 @@ func testAppListHandler(t *testing.T, when spec.G, it spec.S) {
 		router = mux.NewRouter()
 		clientBuilder := new(fake.ClientBuilder)
 
-		apiHandler := &AppHandler{
-			ServerURL:   defaultServerURL,
-			AppRepo:     appRepo,
-			Logger:      logf.Log.WithName(testAppHandlerLoggerName),
-			K8sConfig:   &rest.Config{},
-			BuildClient: clientBuilder.Spy,
-		}
+		apiHandler := NewAppHandler(
+			logf.Log.WithName(testAppHandlerLoggerName),
+			defaultServerURL,
+			appRepo,
+			clientBuilder.Spy,
+			&rest.Config{},
+		)
 		apiHandler.RegisterRoutes(router)
 	})
 

--- a/apis/package_handler.go
+++ b/apis/package_handler.go
@@ -6,9 +6,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/gorilla/mux"
-
 	"github.com/go-logr/logr"
+	"github.com/gorilla/mux"
 
 	"code.cloudfoundry.org/cf-k8s-api/payloads"
 
@@ -33,15 +32,32 @@ type CFPackageRepository interface {
 }
 
 type PackageHandler struct {
-	ServerURL   string
-	PackageRepo CFPackageRepository
-	AppRepo     CFAppRepository
-	K8sConfig   *rest.Config
-	Logger      logr.Logger
-	BuildClient ClientBuilder
+	logger      logr.Logger
+	serverURL   string
+	packageRepo CFPackageRepository
+	appRepo     CFAppRepository
+	k8sConfig   *rest.Config
+	buildClient ClientBuilder
 }
 
-func (h PackageHandler) PackageCreateHandler(w http.ResponseWriter, req *http.Request) {
+func NewPackageHandler(
+	logger logr.Logger,
+	serverURL string,
+	packageRepo CFPackageRepository,
+	appRepo CFAppRepository,
+	buildClient ClientBuilder,
+	k8sConfig *rest.Config) *PackageHandler {
+	return &PackageHandler{
+		logger:      logger,
+		serverURL:   serverURL,
+		packageRepo: packageRepo,
+		appRepo:     appRepo,
+		buildClient: buildClient,
+		k8sConfig:   k8sConfig,
+	}
+}
+
+func (h PackageHandler) packageCreateHandler(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	var payload payloads.PackageCreate
@@ -51,77 +67,77 @@ func (h PackageHandler) PackageCreateHandler(w http.ResponseWriter, req *http.Re
 		return
 	}
 
-	client, err := h.BuildClient(h.K8sConfig)
+	client, err := h.buildClient(h.k8sConfig)
 	if err != nil {
-		h.Logger.Info("Error building k8s client", "error", err.Error())
+		h.logger.Info("Error building k8s client", "error", err.Error())
 		writeUnknownErrorResponse(w)
 		return
 	}
 
-	appRecord, err := h.AppRepo.FetchApp(req.Context(), client, payload.Relationships.App.Data.GUID)
+	appRecord, err := h.appRepo.FetchApp(req.Context(), client, payload.Relationships.App.Data.GUID)
 	if err != nil {
 		switch err.(type) {
 		case repositories.NotFoundError:
-			h.Logger.Info("App not found", "App GUID", payload.Relationships.App.Data.GUID)
+			h.logger.Info("App not found", "App GUID", payload.Relationships.App.Data.GUID)
 			writeUnprocessableEntityError(w, "App is invalid. Ensure it exists and you have access to it.")
 		default:
-			h.Logger.Info("Error finding App", "App GUID", payload.Relationships.App.Data.GUID)
+			h.logger.Info("Error finding App", "App GUID", payload.Relationships.App.Data.GUID)
 			writeUnknownErrorResponse(w)
 		}
 		return
 	}
 
-	record, err := h.PackageRepo.CreatePackage(req.Context(), client, payload.ToMessage(appRecord.SpaceGUID))
+	record, err := h.packageRepo.CreatePackage(req.Context(), client, payload.ToMessage(appRecord.SpaceGUID))
 	if err != nil {
-		h.Logger.Info("Error creating package with repository", "error", err.Error())
+		h.logger.Info("Error creating package with repository", "error", err.Error())
 		writeUnknownErrorResponse(w)
 		return
 	}
 
-	res := presenter.ForPackage(record, h.ServerURL)
+	res := presenter.ForPackage(record, h.serverURL)
 	w.WriteHeader(http.StatusCreated)
 	err = json.NewEncoder(w).Encode(res)
 	if err != nil { // untested
-		h.Logger.Info("Error encoding JSON response", "error", err.Error())
+		h.logger.Info("Error encoding JSON response", "error", err.Error())
 		writeUnknownErrorResponse(w)
 		return
 	}
 }
 
-func (h PackageHandler) PackageUploadHandler(w http.ResponseWriter, req *http.Request) {
+func (h PackageHandler) packageUploadHandler(w http.ResponseWriter, req *http.Request) {
 	packageGUID := mux.Vars(req)["guid"]
 
 	w.Header().Set("Content-Type", "application/json")
 
-	client, err := h.BuildClient(h.K8sConfig)
+	client, err := h.buildClient(h.k8sConfig)
 	if err != nil {
-		h.Logger.Info("Error building k8s client", "error", err.Error())
+		h.logger.Info("Error building k8s client", "error", err.Error())
 		writeUnknownErrorResponse(w)
 		return
 	}
 
-	record, err := h.PackageRepo.FetchPackage(req.Context(), client, packageGUID)
+	record, err := h.packageRepo.FetchPackage(req.Context(), client, packageGUID)
 	if err != nil {
 		switch {
 		case errors.As(err, new(repositories.NotFoundError)):
 			writeNotFoundErrorResponse(w, "Package")
 		default:
-			h.Logger.Info("Error fetching package with repository", "error", err.Error())
+			h.logger.Info("Error fetching package with repository", "error", err.Error())
 			writeUnknownErrorResponse(w)
 		}
 		return
 	}
 
-	res := presenter.ForPackage(record, h.ServerURL)
+	res := presenter.ForPackage(record, h.serverURL)
 	err = json.NewEncoder(w).Encode(res)
 	if err != nil { // untested
-		h.Logger.Info("Error encoding JSON response", "error", err.Error())
+		h.logger.Info("Error encoding JSON response", "error", err.Error())
 		writeUnknownErrorResponse(w)
 		return
 	}
 }
 
 func (h *PackageHandler) RegisterRoutes(router *mux.Router) {
-	router.Path(PackageCreateEndpoint).Methods("POST").HandlerFunc(h.PackageCreateHandler)
-	router.Path(PackageUploadEndpoint).Methods("POST").HandlerFunc(h.PackageUploadHandler)
+	router.Path(PackageCreateEndpoint).Methods("POST").HandlerFunc(h.packageCreateHandler)
+	router.Path(PackageUploadEndpoint).Methods("POST").HandlerFunc(h.packageUploadHandler)
 }

--- a/apis/package_handler_test.go
+++ b/apis/package_handler_test.go
@@ -91,14 +91,14 @@ func testPackageCreateHandler(t *testing.T, when spec.G, it spec.S) {
 
 		clientBuilder = new(fake.ClientBuilder)
 
-		apiHandler := &PackageHandler{
-			ServerURL:   defaultServerURL,
-			PackageRepo: packageRepo,
-			AppRepo:     appRepo,
-			K8sConfig:   &rest.Config{},
-			Logger:      logf.Log.WithName(testPackageHandlerLoggerName),
-			BuildClient: clientBuilder.Spy,
-		}
+		apiHandler := NewPackageHandler(
+			logf.Log.WithName(testPackageHandlerLoggerName),
+			defaultServerURL,
+			packageRepo,
+			appRepo,
+			clientBuilder.Spy,
+			&rest.Config{},
+		)
 		apiHandler.RegisterRoutes(router)
 	})
 
@@ -422,14 +422,14 @@ func testPackageUploadHandler(t *testing.T, when spec.G, it spec.S) {
 		appRepo = new(fake.CFAppRepository)
 		clientBuilder = new(fake.ClientBuilder)
 
-		apiHandler := &PackageHandler{
-			ServerURL:   defaultServerURL,
-			PackageRepo: packageRepo,
-			AppRepo:     appRepo,
-			K8sConfig:   &rest.Config{},
-			Logger:      logf.Log.WithName(testPackageHandlerLoggerName),
-			BuildClient: clientBuilder.Spy,
-		}
+		apiHandler := NewPackageHandler(
+			logf.Log.WithName(testPackageHandlerLoggerName),
+			defaultServerURL,
+			packageRepo,
+			appRepo,
+			clientBuilder.Spy,
+			&rest.Config{})
+
 		apiHandler.RegisterRoutes(router)
 	})
 

--- a/apis/resource_matches_handler.go
+++ b/apis/resource_matches_handler.go
@@ -11,15 +11,19 @@ const (
 )
 
 type ResourceMatchesHandler struct {
-	ServerURL string
+	serverURL string
 }
 
-func (h *ResourceMatchesHandler) ResourceMatchesPostHandler(w http.ResponseWriter, r *http.Request) {
+func NewResourceMatchesHandler(serverURL string) *ResourceMatchesHandler {
+	return &ResourceMatchesHandler{serverURL: serverURL}
+}
+
+func (h *ResourceMatchesHandler) resourceMatchesPostHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	w.Write([]byte(`{"resources":[]}`))
 }
 
 func (h *ResourceMatchesHandler) RegisterRoutes(router *mux.Router) {
-	router.Path(ResourceMatchesEndpoint).Methods("POST").HandlerFunc(h.ResourceMatchesPostHandler)
+	router.Path(ResourceMatchesEndpoint).Methods("POST").HandlerFunc(h.resourceMatchesPostHandler)
 }

--- a/apis/resource_matches_handler_test.go
+++ b/apis/resource_matches_handler_test.go
@@ -37,7 +37,7 @@ func testResourceMatchesHandler(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
 		rr = httptest.NewRecorder()
 		router = mux.NewRouter()
-		apiHandler := &ResourceMatchesHandler{}
+		apiHandler := NewResourceMatchesHandler("foo://my-server")
 		apiHandler.RegisterRoutes(router)
 	})
 

--- a/apis/root_handler.go
+++ b/apis/root_handler.go
@@ -11,16 +11,20 @@ const (
 )
 
 type RootHandler struct {
-	ServerURL string
+	serverURL string
 }
 
-func (h *RootHandler) RootGetHandler(w http.ResponseWriter, r *http.Request) {
-	body := `{"links":{"self":{"href":"` + h.ServerURL + `"},"bits_service":null,"cloud_controller_v2":null,"cloud_controller_v3":{"href":"` + h.ServerURL + `/v3","meta":{"version":"3.90.0"}},"network_policy_v0":null,"network_policy_v1":null,"login":null,"uaa":null,"credhub":null,"routing":null,"logging":null,"log_cache":null,"log_stream":null,"app_ssh":null}}`
+func NewRootHandler(serverURL string) *RootHandler {
+	return &RootHandler{serverURL: serverURL}
+}
+
+func (h *RootHandler) rootGetHandler(w http.ResponseWriter, r *http.Request) {
+	body := `{"links":{"self":{"href":"` + h.serverURL + `"},"bits_service":null,"cloud_controller_v2":null,"cloud_controller_v3":{"href":"` + h.serverURL + `/v3","meta":{"version":"3.90.0"}},"network_policy_v0":null,"network_policy_v1":null,"login":null,"uaa":null,"credhub":null,"routing":null,"logging":null,"log_cache":null,"log_stream":null,"app_ssh":null}}`
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Write([]byte(body))
 }
 
 func (h *RootHandler) RegisterRoutes(router *mux.Router) {
-	router.Path(RootGetEndpoint).Methods("GET").HandlerFunc(h.RootGetHandler)
+	router.Path(RootGetEndpoint).Methods("GET").HandlerFunc(h.rootGetHandler)
 }

--- a/apis/root_handler_test.go
+++ b/apis/root_handler_test.go
@@ -29,9 +29,7 @@ func testRootAPI(t *testing.T, when spec.G, it spec.S) {
 		rr = httptest.NewRecorder()
 		router := mux.NewRouter()
 
-		apiHandler := apis.RootHandler{
-			ServerURL: defaultServerURL,
-		}
+		apiHandler := apis.NewRootHandler(defaultServerURL)
 		apiHandler.RegisterRoutes(router)
 
 		router.ServeHTTP(rr, req)

--- a/apis/root_v3_handler.go
+++ b/apis/root_v3_handler.go
@@ -11,14 +11,18 @@ const (
 )
 
 type RootV3Handler struct {
-	ServerURL string
+	serverURL string
 }
 
-func (h *RootV3Handler) RootV3GetHandler(w http.ResponseWriter, r *http.Request) {
+func NewRootV3Handler(serverURL string) *RootV3Handler {
+	return &RootV3Handler{serverURL: serverURL}
+}
+
+func (h *RootV3Handler) rootV3GetHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{"links":{"self":{"href":"` + h.ServerURL + `/v3"}}}`))
+	w.Write([]byte(`{"links":{"self":{"href":"` + h.serverURL + `/v3"}}}`))
 }
 
 func (h *RootV3Handler) RegisterRoutes(router *mux.Router) {
-	router.Path(RootV3GetEndpoint).Methods("GET").HandlerFunc(h.RootV3GetHandler)
+	router.Path(RootV3GetEndpoint).Methods("GET").HandlerFunc(h.rootV3GetHandler)
 }

--- a/apis/root_v3_handler_test.go
+++ b/apis/root_v3_handler_test.go
@@ -28,9 +28,7 @@ func testRootV3API(t *testing.T, when spec.G, it spec.S) {
 		rr = httptest.NewRecorder()
 		router := mux.NewRouter()
 
-		apiHandler := apis.RootV3Handler{
-			ServerURL: defaultServerURL,
-		}
+		apiHandler := apis.NewRootV3Handler(defaultServerURL)
 		apiHandler.RegisterRoutes(router)
 
 		router.ServeHTTP(rr, req)

--- a/main.go
+++ b/main.go
@@ -49,39 +49,33 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zapOpts)))
 
 	handlers := []APIHandler{
-		&apis.RootV3Handler{
-			ServerURL: config.ServerURL,
-		},
-		&apis.RootHandler{
-			ServerURL: config.ServerURL,
-		},
-		&apis.ResourceMatchesHandler{
-			ServerURL: config.ServerURL,
-		},
-		&apis.AppHandler{
-			ServerURL:   config.ServerURL,
-			AppRepo:     &repositories.AppRepo{},
-			Logger:      ctrl.Log.WithName("AppHandler"),
-			K8sConfig:   k8sClientConfig,
-			BuildClient: repositories.BuildClient,
-		},
-		&apis.RouteHandler{
-			ServerURL:   config.ServerURL,
-			RouteRepo:   &repositories.RouteRepo{},
-			DomainRepo:  &repositories.DomainRepo{},
-			AppRepo:     &repositories.AppRepo{},
-			Logger:      ctrl.Log.WithName("RouteHandler"),
-			K8sConfig:   k8sClientConfig,
-			BuildClient: repositories.BuildClient,
-		},
-		&apis.PackageHandler{
-			ServerURL:   config.ServerURL,
-			PackageRepo: &repositories.PackageRepo{},
-			AppRepo:     &repositories.AppRepo{},
-			K8sConfig:   k8sClientConfig,
-			Logger:      ctrl.Log.WithName("PackageHandler"),
-			BuildClient: repositories.BuildClient,
-		},
+		apis.NewRootV3Handler(config.ServerURL),
+		apis.NewRootHandler(config.ServerURL),
+		apis.NewResourceMatchesHandler(config.ServerURL),
+		apis.NewAppHandler(
+			ctrl.Log.WithName("AppHandler"),
+			config.ServerURL,
+			&repositories.AppRepo{},
+			repositories.BuildClient,
+			k8sClientConfig,
+		),
+		apis.NewRouteHandler(
+			ctrl.Log.WithName("RouteHandler"),
+			config.ServerURL,
+			&repositories.RouteRepo{},
+			&repositories.DomainRepo{},
+			&repositories.AppRepo{},
+			repositories.BuildClient,
+			k8sClientConfig,
+		),
+		apis.NewPackageHandler(
+			ctrl.Log.WithName("PackageHandler"),
+			config.ServerURL,
+			&repositories.PackageRepo{},
+			&repositories.AppRepo{},
+			repositories.BuildClient,
+			k8sClientConfig,
+		),
 	}
 
 	router := mux.NewRouter()


### PR DESCRIPTION

## Is there a related GitHub Issue?
No

## What is this change about?
Introduce constructors for rest handlers. This is useful because:
* handlers fields can be private (basic OOP principle)
* Introducing a new field in the constructor would result into compilation errors wherever the constructor is invoked, therefore one will make sure to wire the handler dependencies properly

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Not really, this is simple refactoring. However, run all tests, see them pass

## Tag your pair
@georgethebeatle 
