### PR TITLE
Add missing RBAC annotation for CFPackages

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -68,3 +68,21 @@ rules:
   - cfapps/status
   verbs:
   - get
+- apiGroups:
+  - workloads.cloudfoundry.org
+  resources:
+  - cfpackages
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - workloads.cloudfoundry.org
+  resources:
+  - cfpackages/status
+  verbs:
+  - get

--- a/repositories/package_repository.go
+++ b/repositories/package_repository.go
@@ -14,6 +14,9 @@ const (
 	kind = "CFPackage"
 )
 
+//+kubebuilder:rbac:groups=workloads.cloudfoundry.org,resources=cfpackages,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=workloads.cloudfoundry.org,resources=cfpackages/status,verbs=get
+
 type PackageCreateMessage struct {
 	Type      string
 	AppGUID   string


### PR DESCRIPTION
## Is there a related GitHub Issue?
#37 

## What is this change about?
Add rbac annotations so that the deployed version of the API can create CFPackage records

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Follow the Acceptance Criteria on #37 

## Tag your pair, your PM, and/or team
Paired with @acosta11 