### PR TITLE
Fix CFBuild Status Conditions

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ func main() {
 			&repositories.PackageRepo{},
 			repositories.BuildClient,
 			k8sClientConfig,
-    ),
+		),
 		apis.NewOrgHandler(
 			repositories.NewOrgRepo(config.RootNamespace, privilegedClient),
 			config.ServerURL,

--- a/repositories/package_repository_test.go
+++ b/repositories/package_repository_test.go
@@ -75,11 +75,11 @@ func testCreatePackage(t *testing.T, when spec.G, it spec.S) {
 
 		createdAt, err := time.Parse(time.RFC3339, returnedPackageRecord.CreatedAt)
 		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(createdAt).To(BeTemporally("~", time.Now(), time.Second))
+		g.Expect(createdAt).To(BeTemporally("~", time.Now(), timeCheckThreshold*time.Second))
 
 		updatedAt, err := time.Parse(time.RFC3339, returnedPackageRecord.CreatedAt)
 		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(updatedAt).To(BeTemporally("~", time.Now(), time.Second))
+		g.Expect(updatedAt).To(BeTemporally("~", time.Now(), timeCheckThreshold*time.Second))
 
 		packageNSName := types.NamespacedName{Name: packageGUID, Namespace: spaceGUID}
 		createdCFPackage := new(workloadsv1alpha1.CFPackage)
@@ -190,11 +190,11 @@ func testFetchPackage(t *testing.T, when spec.G, it spec.S) {
 
 			createdAt, err := time.Parse(time.RFC3339, record.CreatedAt)
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(createdAt).To(BeTemporally("~", time.Now(), time.Second))
+			g.Expect(createdAt).To(BeTemporally("~", time.Now(), timeCheckThreshold*time.Second))
 
 			updatedAt, err := time.Parse(time.RFC3339, record.CreatedAt)
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(updatedAt).To(BeTemporally("~", time.Now(), time.Second))
+			g.Expect(updatedAt).To(BeTemporally("~", time.Now(), timeCheckThreshold*time.Second))
 		})
 	})
 

--- a/repositories/suite_test.go
+++ b/repositories/suite_test.go
@@ -20,6 +20,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
+const (
+	timeCheckThreshold = 3
+)
+
 var (
 	suite             spec.Suite
 	testEnv           *envtest.Environment


### PR DESCRIPTION
- Also fixed test flakiness with time constant

Co-authored-by: Ashwin Krishna <krishnaas@vmware.com>

## Is there a related GitHub Issue?
No

## What is this change about?
As part of https://github.com/cloudfoundry/cf-k8s-controllers/issues/43 we removed the `"Ready"` Status Condition from the CFBuild Staging process. This PR adjusts the tests and the CFBuild repo to correctly derive the State field from the new Condition Status values.

## Does this PR introduce a breaking change?
no

## Acceptance Steps
Install K8s controllers via README, run api shim locally, create CFApp, CFPackage, CFBuild and confirm state returned by shim matches CFBuild.

## Tag your pair, your PM, and/or team
@akrishna90 
