### PR TITLE
Fixed bug where leading e trimmed from App GUID

### DIFF
--- a/repositories/app_repository.go
+++ b/repositories/app_repository.go
@@ -218,7 +218,7 @@ func (f *AppRepo) GenerateEnvSecretName(appGUID string) string {
 	return appGUID + "-env"
 }
 func (f *AppRepo) extractAppGUIDFromEnvSecretName(envSecretName string) string {
-	return strings.Trim(envSecretName, "-env")
+	return strings.TrimSuffix(envSecretName, "-env")
 }
 
 func (f *AppRepo) appEnvVarsRecordToSecret(envVars AppEnvVarsRecord) corev1.Secret {

--- a/repositories/app_repository_test.go
+++ b/repositories/app_repository_test.go
@@ -542,7 +542,6 @@ func testEnvSecretCreate(t *testing.T, when spec.G, it spec.S) {
 			g.Expect(client.Delete(afterCtx, &lookupSecretK8sResource)).To(Succeed(), "Could not clean up the created App Env Secret")
 		})
 
-		// TODO: this test appears flakey
 		it("returns a record matching the input and no error", func() {
 			g.Expect(returnedAppEnvVarsRecord.AppGUID).To(Equal(testAppEnvSecret.AppGUID))
 			g.Expect(returnedAppEnvVarsRecord.SpaceGUID).To(Equal(testAppEnvSecret.SpaceGUID))
@@ -593,6 +592,16 @@ func testEnvSecretCreate(t *testing.T, when spec.G, it spec.S) {
 			returnedUpdatedAppEnvVarsRecord, returnedUpdatedErr := appRepo.CreateAppEnvironmentVariables(testCtx, client, testAppEnvSecret)
 			g.Expect(returnedUpdatedErr).ToNot(BeNil())
 			g.Expect(returnedUpdatedAppEnvVarsRecord).To(Equal(AppEnvVarsRecord{}))
+		})
+
+		it("the App record GUID returned should equal the App GUID provided", func() {
+			testCtx := context.Background()
+			// Used a strings.Trim to remove characters, which cause the behavior in Issue #103
+			testAppEnvSecret.AppGUID = "estringtrimmedguid"
+
+			returnedUpdatedAppEnvVarsRecord, returnedUpdatedErr := appRepo.CreateAppEnvironmentVariables(testCtx, client, testAppEnvSecret)
+			g.Expect(returnedUpdatedErr).ToNot(HaveOccurred())
+			g.Expect(returnedUpdatedAppEnvVarsRecord.AppGUID).To(Equal(testAppEnvSecret.AppGUID), "Expected App GUID to match after transform")
 		})
 
 	})


### PR DESCRIPTION
## Is there a related GitHub Issue?
Issue #103 

## What is this change about?
Fix bug related to string trimming App GUIDs.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Hard to reproduce bug since it it relies on GUID generation starting with an e.

## Tag your pair, your PM, and/or team
@davewalter @mnitchev 
