### PR TITLE
Add controller-gen and manifests make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ test-e2e:
 run: fmt vet ## Run a controller from your host.
 	go run ./main.go
 
+manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=cf-admin-clusterrole paths=./... output:rbac:artifacts:config=../config/base/rbac
+
 generate: fmt vet
 	go generate ./...
 
@@ -57,6 +60,10 @@ docker-build: ## Build docker image with the manager.
 build-reference: kustomize
 	cd config/base && $(KUSTOMIZE) edit set image cloudfoundry/cf-k8s-api=${IMG}
 	$(KUSTOMIZE) build config/base -o reference/cf-k8s-api.yaml
+
+CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
+controller-gen: ## Download controller-gen locally if necessary.
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.5.0)
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.

--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ Refer to the [default config](config/cf_k8s_api_config.yaml) for the config file
 required.*
 
 ## Regenerate kubernetes resources after making changes
-To regenerate the kubernetes resources under `./config`, run `make generate` or `go generate ./...`
-from the root of the project.
+To regenerate the kubernetes resources under `./config`, run `make manifests` from the root of the project.
 
 ## Generate reference yaml
 ```
@@ -67,4 +66,3 @@ You can deploy the app to your cluster by running `make deploy` from the project
 
 ### Using Kubectl
 You can deploy the app to your cluster by running `kubectl apply -f reference/cf-k8s-api.yaml` from the project root.
-

--- a/repositories/shared.go
+++ b/repositories/shared.go
@@ -8,8 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//go:generate controller-gen rbac:roleName=cf-admin-clusterrole paths=./... output:rbac:artifacts:config=../config/base/rbac
-
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 
 type NotFoundError struct {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No.

## What is this change about?
Source `controller-gen` and generate rbac via `manifests` make target

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Run `make manifests`. It should go get `controller-gen` and regenerate rbac.

## Tag your pair, your PM, and/or team
@davewalter @acosta11 
