### PR TITLE
Restore SubnamespaceAnchors list permission

### DIFF
--- a/apis/org_handler.go
+++ b/apis/org_handler.go
@@ -47,6 +47,7 @@ func (h *OrgHandler) OrgListHandler(w http.ResponseWriter, r *http.Request) {
 
 	orgs, err := h.orgRepo.FetchOrgs(ctx, names)
 	if err != nil {
+		h.logger.Error(err, "failed to fetch orgs")
 		writeUnknownErrorResponse(w)
 
 		return

--- a/config/base/rbac/role.yaml
+++ b/config/base/rbac/role.yaml
@@ -104,3 +104,9 @@ rules:
   - cfpackages/status
   verbs:
   - get
+- apiGroups:
+  - hnc.x-k8s.io
+  resources:
+  - subnamespaceanchors
+  verbs:
+  - list


### PR DESCRIPTION
Make e2e tests green again.

This restores the permission accidentally removed from the service account role in https://github.com/cloudfoundry/cf-k8s-api/commit/8d0de889b