### PR TITLE
API Client can update currentDropletRef for an app via PATCH `/v3/apps/<app_guid>/relationships/current_droplet`

### DIFF
--- a/apis/app_handler.go
+++ b/apis/app_handler.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 	"net/http"
 
+	"code.cloudfoundry.org/cf-k8s-controllers/webhooks/workloads"
+
 	"code.cloudfoundry.org/cf-k8s-api/payloads"
 	"code.cloudfoundry.org/cf-k8s-api/presenter"
 	"code.cloudfoundry.org/cf-k8s-api/repositories"
-	"code.cloudfoundry.org/cf-k8s-controllers/webhooks/workloads"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
@@ -21,9 +22,12 @@ import (
 )
 
 const (
-	AppCreateEndpoint = "/v3/apps"
-	AppGetEndpoint    = "/v3/apps/{guid}"
-	AppListEndpoint   = "/v3/apps"
+	AppCreateEndpoint            = "/v3/apps"
+	AppGetEndpoint               = "/v3/apps/{guid}"
+	AppListEndpoint              = "/v3/apps"
+	AppSetCurrentDropletEndpoint = "/v3/apps/{guid}/current_droplet"
+
+	invalidDropletMsg = "Unable to assign current droplet. Ensure the droplet exists and belongs to this app."
 )
 
 //counterfeiter:generate -o fake -fake-name CFAppRepository . CFAppRepository
@@ -33,26 +37,24 @@ type CFAppRepository interface {
 	FetchNamespace(context.Context, client.Client, string) (repositories.SpaceRecord, error)
 	CreateAppEnvironmentVariables(context.Context, client.Client, repositories.AppEnvVarsRecord) (repositories.AppEnvVarsRecord, error)
 	CreateApp(context.Context, client.Client, repositories.AppRecord) (repositories.AppRecord, error)
+	SetCurrentDroplet(context.Context, client.Client, repositories.SetCurrentDropletMessage) (repositories.CurrentDropletRecord, error)
 }
 
 type AppHandler struct {
 	logger      logr.Logger
 	serverURL   string
 	appRepo     CFAppRepository
+	dropletRepo CFDropletRepository
 	buildClient ClientBuilder
 	k8sConfig   *rest.Config // TODO: this would be global for all requests, not what we want
 }
 
-func NewAppHandler(
-	logger logr.Logger,
-	serverURL string,
-	appRepo CFAppRepository,
-	buildClient ClientBuilder,
-	k8sConfig *rest.Config) *AppHandler {
+func NewAppHandler(logger logr.Logger, serverURL string, appRepo CFAppRepository, dropletRepo CFDropletRepository, buildClient ClientBuilder, k8sConfig *rest.Config) *AppHandler {
 	return &AppHandler{
 		logger:      logger,
 		serverURL:   serverURL,
 		appRepo:     appRepo,
+		dropletRepo: dropletRepo,
 		buildClient: buildClient,
 		k8sConfig:   k8sConfig,
 	}
@@ -217,8 +219,80 @@ func (h *AppHandler) appListHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(responseBody)
 }
 
+func (h *AppHandler) appSetCurrentDropletHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	w.Header().Set("Content-Type", "application/json")
+	vars := mux.Vars(r)
+	appGUID := vars["guid"]
+
+	var payload payloads.AppSetCurrentDroplet
+	rme := DecodeAndValidatePayload(r, &payload)
+	if rme != nil {
+		writeErrorResponse(w, rme)
+		return
+	}
+
+	// TODO: Instantiate config based on bearer token
+	// Spike code from EMEA folks around this: https://github.com/cloudfoundry/cf-crd-explorations/blob/136417fbff507eb13c92cd67e6fed6b061071941/cfshim/handlers/app_handler.go#L78
+	client, err := h.buildClient(h.k8sConfig)
+	if err != nil {
+		h.logger.Error(err, "Unable to create Kubernetes client")
+		writeUnknownErrorResponse(w)
+		return
+	}
+
+	app, err := h.appRepo.FetchApp(ctx, client, appGUID)
+	if err != nil {
+		if errors.As(err, new(repositories.NotFoundError)) {
+			writeNotFoundErrorResponse(w, "App")
+		} else {
+			h.logger.Error(err, "Error fetching app")
+			writeUnknownErrorResponse(w)
+		}
+		return
+	}
+
+	dropletGUID := payload.Data.GUID
+	droplet, err := h.dropletRepo.FetchDroplet(ctx, client, dropletGUID)
+	if err != nil {
+		if errors.As(err, new(repositories.NotFoundError)) {
+			writeUnprocessableEntityError(w, invalidDropletMsg)
+		} else {
+			h.logger.Error(err, "Error fetching droplet")
+			writeUnknownErrorResponse(w)
+		}
+		return
+	}
+
+	if droplet.AppGUID != appGUID {
+		writeUnprocessableEntityError(w, invalidDropletMsg)
+		return
+	}
+
+	currentDroplet, err := h.appRepo.SetCurrentDroplet(ctx, client, repositories.SetCurrentDropletMessage{
+		AppGUID:     appGUID,
+		DropletGUID: dropletGUID,
+		SpaceGUID:   app.SpaceGUID,
+	})
+	if err != nil {
+		h.logger.Error(err, "Error setting current droplet")
+		writeUnknownErrorResponse(w)
+		return
+	}
+
+	responseBody, err := json.Marshal(presenter.ForCurrentDroplet(currentDroplet, h.serverURL))
+	if err != nil { // untested
+		h.logger.Error(err, "Failed to render response")
+		writeUnknownErrorResponse(w)
+		return
+	}
+
+	w.Write(responseBody)
+}
+
 func (h *AppHandler) RegisterRoutes(router *mux.Router) {
 	router.Path(AppGetEndpoint).Methods("GET").HandlerFunc(h.appGetHandler)
 	router.Path(AppListEndpoint).Methods("GET").HandlerFunc(h.appListHandler)
 	router.Path(AppCreateEndpoint).Methods("POST").HandlerFunc(h.appCreateHandler)
+	router.Path(AppSetCurrentDropletEndpoint).Methods("PATCH").HandlerFunc(h.appSetCurrentDropletHandler)
 }

--- a/apis/fake/cfapp_repository.go
+++ b/apis/fake/cfapp_repository.go
@@ -85,6 +85,21 @@ type CFAppRepository struct {
 		result1 repositories.SpaceRecord
 		result2 error
 	}
+	SetCurrentDropletStub        func(context.Context, client.Client, repositories.SetCurrentDropletMessage) (repositories.CurrentDropletRecord, error)
+	setCurrentDropletMutex       sync.RWMutex
+	setCurrentDropletArgsForCall []struct {
+		arg1 context.Context
+		arg2 client.Client
+		arg3 repositories.SetCurrentDropletMessage
+	}
+	setCurrentDropletReturns struct {
+		result1 repositories.CurrentDropletRecord
+		result2 error
+	}
+	setCurrentDropletReturnsOnCall map[int]struct {
+		result1 repositories.CurrentDropletRecord
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -418,6 +433,72 @@ func (fake *CFAppRepository) FetchNamespaceReturnsOnCall(i int, result1 reposito
 	}{result1, result2}
 }
 
+func (fake *CFAppRepository) SetCurrentDroplet(arg1 context.Context, arg2 client.Client, arg3 repositories.SetCurrentDropletMessage) (repositories.CurrentDropletRecord, error) {
+	fake.setCurrentDropletMutex.Lock()
+	ret, specificReturn := fake.setCurrentDropletReturnsOnCall[len(fake.setCurrentDropletArgsForCall)]
+	fake.setCurrentDropletArgsForCall = append(fake.setCurrentDropletArgsForCall, struct {
+		arg1 context.Context
+		arg2 client.Client
+		arg3 repositories.SetCurrentDropletMessage
+	}{arg1, arg2, arg3})
+	stub := fake.SetCurrentDropletStub
+	fakeReturns := fake.setCurrentDropletReturns
+	fake.recordInvocation("SetCurrentDroplet", []interface{}{arg1, arg2, arg3})
+	fake.setCurrentDropletMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *CFAppRepository) SetCurrentDropletCallCount() int {
+	fake.setCurrentDropletMutex.RLock()
+	defer fake.setCurrentDropletMutex.RUnlock()
+	return len(fake.setCurrentDropletArgsForCall)
+}
+
+func (fake *CFAppRepository) SetCurrentDropletCalls(stub func(context.Context, client.Client, repositories.SetCurrentDropletMessage) (repositories.CurrentDropletRecord, error)) {
+	fake.setCurrentDropletMutex.Lock()
+	defer fake.setCurrentDropletMutex.Unlock()
+	fake.SetCurrentDropletStub = stub
+}
+
+func (fake *CFAppRepository) SetCurrentDropletArgsForCall(i int) (context.Context, client.Client, repositories.SetCurrentDropletMessage) {
+	fake.setCurrentDropletMutex.RLock()
+	defer fake.setCurrentDropletMutex.RUnlock()
+	argsForCall := fake.setCurrentDropletArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *CFAppRepository) SetCurrentDropletReturns(result1 repositories.CurrentDropletRecord, result2 error) {
+	fake.setCurrentDropletMutex.Lock()
+	defer fake.setCurrentDropletMutex.Unlock()
+	fake.SetCurrentDropletStub = nil
+	fake.setCurrentDropletReturns = struct {
+		result1 repositories.CurrentDropletRecord
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CFAppRepository) SetCurrentDropletReturnsOnCall(i int, result1 repositories.CurrentDropletRecord, result2 error) {
+	fake.setCurrentDropletMutex.Lock()
+	defer fake.setCurrentDropletMutex.Unlock()
+	fake.SetCurrentDropletStub = nil
+	if fake.setCurrentDropletReturnsOnCall == nil {
+		fake.setCurrentDropletReturnsOnCall = make(map[int]struct {
+			result1 repositories.CurrentDropletRecord
+			result2 error
+		})
+	}
+	fake.setCurrentDropletReturnsOnCall[i] = struct {
+		result1 repositories.CurrentDropletRecord
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *CFAppRepository) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -431,6 +512,8 @@ func (fake *CFAppRepository) Invocations() map[string][][]interface{} {
 	defer fake.fetchAppListMutex.RUnlock()
 	fake.fetchNamespaceMutex.RLock()
 	defer fake.fetchNamespaceMutex.RUnlock()
+	fake.setCurrentDropletMutex.RLock()
+	defer fake.setCurrentDropletMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/apis/route_handler_test.go
+++ b/apis/route_handler_test.go
@@ -1,15 +1,16 @@
 package apis_test
 
 import (
-	. "code.cloudfoundry.org/cf-k8s-api/apis"
-	"code.cloudfoundry.org/cf-k8s-api/apis/fake"
-	"code.cloudfoundry.org/cf-k8s-api/repositories"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+
+	. "code.cloudfoundry.org/cf-k8s-api/apis"
+	"code.cloudfoundry.org/cf-k8s-api/apis/fake"
+	"code.cloudfoundry.org/cf-k8s-api/repositories"
 
 	"github.com/gorilla/mux"
 	. "github.com/onsi/ginkgo"
@@ -97,46 +98,46 @@ var _ = Describe("RouteHandler", func() {
 
 			It("returns the Route in the response", func() {
 				expectedBody := `{
-				"guid": "test-route-guid",
-				"port": null,
-				"path": "",
-				"protocol": "http",
-				"host": "test-route-host",
-				"url": "test-route-host.example.org",
-				"created_at": "create-time",
-				"updated_at": "update-time",
-				"destinations": null,
-				"relationships": {
-					"space": {
-						"data": {
-							"guid": "test-space-guid"
+					"guid": "test-route-guid",
+					"port": null,
+					"path": "",
+					"protocol": "http",
+					"host": "test-route-host",
+					"url": "test-route-host.example.org",
+					"created_at": "create-time",
+					"updated_at": "update-time",
+					"destinations": null,
+					"relationships": {
+						"space": {
+							"data": {
+								"guid": "test-space-guid"
+							}
+						},
+						"domain": {
+							"data": {
+								"guid": "test-domain-guid"
+							}
 						}
 					},
-					"domain": {
-						"data": {
-							"guid": "test-domain-guid"
+					"metadata": {
+						"labels": {},
+						"annotations": {}
+					},
+					"links": {
+						"self":{
+							"href": "https://api.example.org/v3/routes/test-route-guid"
+						},
+						"space":{
+							"href": "https://api.example.org/v3/spaces/test-space-guid"
+						},
+						"domain":{
+							"href": "https://api.example.org/v3/domains/test-domain-guid"
+						},
+						"destinations":{
+							"href": "https://api.example.org/v3/routes/test-route-guid/destinations"
 						}
 					}
-				},
-				"metadata": {
-					"labels": {},
-					"annotations": {}
-				},
-				"links": {
-					"self":{
-						"href": "https://api.example.org/v3/routes/test-route-guid"
-					},
-					"space":{
-						"href": "https://api.example.org/v3/spaces/test-space-guid"
-					},
-					"domain":{
-						"href": "https://api.example.org/v3/domains/test-domain-guid"
-					},
-					"destinations":{
-						"href": "https://api.example.org/v3/routes/test-route-guid/destinations"
-					}
-				}
-			}`
+				}`
 
 				Expect(rr.Body.String()).To(MatchJSON(expectedBody), "Response body matches response:")
 			})
@@ -290,46 +291,46 @@ var _ = Describe("RouteHandler", func() {
 
 				It("returns the created route in the response", func() {
 					Expect(rr.Body.String()).To(MatchJSON(`{
-					"guid": "test-route-guid",
-					"protocol": "http",
-					"port": null,
-					"host": "test-route-host",
-					"path": "/test-route-path",
-					"url": "test-route-host.test-domain-name/test-route-path",
-					"created_at": "create-time",
-					"updated_at": "update-time",
-					"destinations": null,
-					"metadata": {
-						"labels": {},
-						"annotations": {}
-					},
-					"relationships": {
-						"space": {
-							"data": {
-								"guid": "test-space-guid"
+						"guid": "test-route-guid",
+						"protocol": "http",
+						"port": null,
+						"host": "test-route-host",
+						"path": "/test-route-path",
+						"url": "test-route-host.test-domain-name/test-route-path",
+						"created_at": "create-time",
+						"updated_at": "update-time",
+						"destinations": null,
+						"metadata": {
+							"labels": {},
+							"annotations": {}
+						},
+						"relationships": {
+							"space": {
+								"data": {
+									"guid": "test-space-guid"
+								}
+							},
+							"domain": {
+								"data": {
+									"guid": "test-domain-guid"
+								}
 							}
 						},
-						"domain": {
-							"data": {
-								"guid": "test-domain-guid"
+						"links": {
+							"self": {
+								"href": "https://api.example.org/v3/routes/test-route-guid"
+							},
+							"space": {
+								"href": "https://api.example.org/v3/spaces/test-space-guid"
+							},
+							"domain": {
+								"href": "https://api.example.org/v3/domains/test-domain-guid"
+							},
+							"destinations": {
+								"href": "https://api.example.org/v3/routes/test-route-guid/destinations"
 							}
 						}
-					},
-					"links": {
-						"self": {
-							"href": "https://api.example.org/v3/routes/test-route-guid"
-						},
-						"space": {
-							"href": "https://api.example.org/v3/spaces/test-space-guid"
-						},
-						"domain": {
-							"href": "https://api.example.org/v3/domains/test-domain-guid"
-						},
-						"destinations": {
-							"href": "https://api.example.org/v3/routes/test-route-guid/destinations"
-						}
-					}
-				}`), "Response body mismatch")
+					}`), "Response body mismatch")
 				})
 			})
 
@@ -382,14 +383,14 @@ var _ = Describe("RouteHandler", func() {
 
 			It("has the expected error response body", func() {
 				Expect(rr.Body.String()).To(MatchJSON(`{
-				"errors": [
-					{
-						"title": "CF-MessageParseError",
-						"detail": "Request invalid due to parse error: invalid request body",
-						"code": 1001
-					}
-				]
-			}`), "Response body matches response:")
+					"errors": [
+						{
+							"title": "CF-MessageParseError",
+							"detail": "Request invalid due to parse error: invalid request body",
+							"code": 1001
+						}
+					]
+				}`), "Response body matches response:")
 			})
 		})
 
@@ -398,293 +399,158 @@ var _ = Describe("RouteHandler", func() {
 				makePostRequest(`{"description" : "Invalid Request"}`)
 			})
 
-			It("returns a status 422 Unprocessable Entity", func() {
-				Expect(rr.Code).To(Equal(http.StatusUnprocessableEntity), "Matching HTTP response code:")
-			})
-
-			It("returns Content-Type as JSON in header", func() {
-				Expect(rr.Header().Get("Content-Type")).To(Equal(jsonHeader), "Matching Content-Type header:")
-			})
-
-			It("has the expected error response body", func() {
-				Expect(rr.Body.String()).To(MatchJSON(`{
-				"errors": [
-					{
-						"detail": "invalid request body: json: unknown field \"description\"",
-						"title": "CF-UnprocessableEntity",
-						"code": 10008
-					}
-				]
-			}`), "Response body matches response:")
-			})
+			itRespondsWithUnprocessableEntity(`invalid request body: json: unknown field "description"`, getRR)
 		})
 
 		When("the host is missing", func() {
 			BeforeEach(func() {
 				makePostRequest(`{
-				"relationships": {
-					"domain": {
-						"data": {
-							"guid": "0b78dd5d-c723-4f2e-b168-df3c3e1d0806"
-						}
-					},
-					"space": {
-						"data": {
-							"guid": "0c78dd5d-c723-4f2e-b168-df3c3e1d0806"
+					"relationships": {
+						"domain": {
+							"data": {
+								"guid": "0b78dd5d-c723-4f2e-b168-df3c3e1d0806"
+							}
+						},
+						"space": {
+							"data": {
+								"guid": "0c78dd5d-c723-4f2e-b168-df3c3e1d0806"
+							}
 						}
 					}
-				}
-			}`)
+				}`)
 			})
 
-			It("returns a status 422 Unprocessable Entity", func() {
-				Expect(rr.Code).To(Equal(http.StatusUnprocessableEntity), "Matching HTTP response code:")
-			})
-
-			It("returns Content-Type as JSON in header", func() {
-				contentTypeHeader := rr.Header().Get("Content-Type")
-				Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
-			})
-
-			It("has the expected error response body", func() {
-				Expect(rr.Body.String()).To(MatchJSON(`{
-				"errors": [
-					{
-						"detail": "Key: 'RouteCreate.Host' Error:Field validation for 'Host' failed on the 'hostname_rfc1123' tag",
-						"title": "CF-UnprocessableEntity",
-						"code": 10008
-					}
-				]
-			}`), "Response body matches response:")
-			})
+			itRespondsWithUnprocessableEntity(
+				"Key: 'RouteCreate.Host' Error:Field validation for 'Host' failed on the 'hostname_rfc1123' tag",
+				getRR,
+			)
 		})
 
 		When("the host is not a string", func() {
 			BeforeEach(func() {
 				makePostRequest(`{
-				"host": 12345,
-				"relationships": {
-					"space": {
-						"data": {
-							"guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
+					"host": 12345,
+					"relationships": {
+						"space": {
+							"data": {
+								"guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
+							}
 						}
 					}
-				}
-			}`)
+				}`)
 			})
 
-			It("returns a status 422 Unprocessable Entity", func() {
-				Expect(rr.Code).To(Equal(http.StatusUnprocessableEntity), "Matching HTTP response code:")
-			})
-
-			It("returns Content-Type as JSON in header", func() {
-				Expect(rr.Header().Get("Content-Type")).To(Equal(jsonHeader), "Matching Content-Type header:")
-			})
-
-			It("has the expected error response body", func() {
-				Expect(rr.Body.String()).To(MatchJSON(`{
-				"errors": [
-					{
-						"detail": "Host must be a string",
-						"title": "CF-UnprocessableEntity",
-						"code":   10008
-					}
-				]
-			}`), "Response body matches response:")
-			})
+			itRespondsWithUnprocessableEntity("Host must be a string", getRR)
 		})
 
 		When("the host format is invalid", func() {
 			BeforeEach(func() {
 				makePostRequest(`{
-				"host": "!-invalid-hostname-!",
-				"relationships": {
-					"domain": {
-						"data": {
-							"guid": "0b78dd5d-c723-4f2e-b168-df3c3e1d0806"
-						}
-					},
-					"space": {
-						"data": {
-							"guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
+					"host": "!-invalid-hostname-!",
+					"relationships": {
+						"domain": {
+							"data": {
+								"guid": "0b78dd5d-c723-4f2e-b168-df3c3e1d0806"
+							}
+						},
+						"space": {
+							"data": {
+								"guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
+							}
 						}
 					}
-				}
-			}`)
+				}`)
 			})
 
-			It("returns a status 422 Unprocessable Entity", func() {
-				Expect(rr.Code).To(Equal(http.StatusUnprocessableEntity), "Matching HTTP response code:")
-			})
-
-			It("returns Content-Type as JSON in header", func() {
-				Expect(rr.Header().Get("Content-Type")).To(Equal(jsonHeader), "Matching Content-Type header:")
-			})
-
-			It("has the expected error response body", func() {
-				Expect(rr.Body.String()).To(MatchJSON(`{
-				"errors": [
-					{
-						"detail": "Key: 'RouteCreate.Host' Error:Field validation for 'Host' failed on the 'hostname_rfc1123' tag",
-						"title": "CF-UnprocessableEntity",
-						"code":   10008
-					}
-				]
-			}`), "Response body matches response:")
-			})
+			itRespondsWithUnprocessableEntity(
+				"Key: 'RouteCreate.Host' Error:Field validation for 'Host' failed on the 'hostname_rfc1123' tag",
+				getRR,
+			)
 		})
 
 		When("the host too long", func() {
 			BeforeEach(func() {
 				makePostRequest(`{
-				"host": "a-really-long-hostname-that-is-not-valid-according-to-the-dns-rfc",
-				"relationships": {
-					"domain": {
-						"data": {
-							"guid": "0b78dd5d-c723-4f2e-b168-df3c3e1d0806"
-						}
-					},
-					"space": {
-						"data": {
-							"guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
+					"host": "a-really-long-hostname-that-is-not-valid-according-to-the-dns-rfc",
+					"relationships": {
+						"domain": {
+							"data": {
+								"guid": "0b78dd5d-c723-4f2e-b168-df3c3e1d0806"
+							}
+						},
+						"space": {
+							"data": {
+								"guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
+							}
 						}
 					}
-				}
-			}`)
+				}`)
 			})
 
-			It("returns a status 422 Unprocessable Entity", func() {
-				Expect(rr.Code).To(Equal(http.StatusUnprocessableEntity), "Matching HTTP response code:")
-			})
-
-			It("returns Content-Type as JSON in header", func() {
-				Expect(rr.Header().Get("Content-Type")).To(Equal(jsonHeader), "Matching Content-Type header:")
-			})
-
-			It("has the expected error response body", func() {
-				Expect(rr.Body.String()).To(MatchJSON(`{
-				"errors": [
-					{
-						"detail": "Key: 'RouteCreate.Host' Error:Field validation for 'Host' failed on the 'hostname_rfc1123' tag",
-						"title": "CF-UnprocessableEntity",
-						"code":   10008
-					}
-				]
-			}`), "Response body matches response:")
-			})
+			itRespondsWithUnprocessableEntity(
+				"Key: 'RouteCreate.Host' Error:Field validation for 'Host' failed on the 'hostname_rfc1123' tag",
+				getRR,
+			)
 		})
 
 		When("the path is missing a leading /", func() {
 			BeforeEach(func() {
 				makePostRequest(`{
-				"host": "test-route-host",
-				"path": "invalid/path",
-				 "relationships": {
-					"domain": {
-						"data": {
-							"guid": "0b78dd5d-c723-4f2e-b168-df3c3e1d0806"
-						}
-					},
-					"space": {
-						"data": {
-							"guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
+					"host": "test-route-host",
+					"path": "invalid/path",
+					 "relationships": {
+						"domain": {
+							"data": {
+								"guid": "0b78dd5d-c723-4f2e-b168-df3c3e1d0806"
+							}
+						},
+						"space": {
+							"data": {
+								"guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
+							}
 						}
 					}
-				}
-			}`)
+				}`)
 			})
 
-			It("returns a status 422 Unprocessable Entity", func() {
-				Expect(rr.Code).To(Equal(http.StatusUnprocessableEntity), "Matching HTTP response code:")
-			})
-
-			It("returns Content-Type as JSON in header", func() {
-				Expect(rr.Header().Get("Content-Type")).To(Equal(jsonHeader), "Matching Content-Type header:")
-			})
-
-			It("has the expected error response body", func() {
-				Expect(rr.Body.String()).To(MatchJSON(`{
-				"errors": [
-					{
-						"detail": "Key: 'RouteCreate.Path' Error:Field validation for 'Path' failed on the 'routepathstartswithslash' tag",
-						"title": "CF-UnprocessableEntity",
-						"code":   10008
-					}
-				]
-			}`), "Response body matches response:")
-			})
+			itRespondsWithUnprocessableEntity(
+				"Key: 'RouteCreate.Path' Error:Field validation for 'Path' failed on the 'routepathstartswithslash' tag",
+				getRR,
+			)
 		})
 
 		When("the request body is missing the domain relationship", func() {
 			BeforeEach(func() {
 				makePostRequest(`{
-				"host": "test-route-host",
-				"relationships": {
-					"space": {
-						"data": {
-							"guid": "0c78dd5d-c723-4f2e-b168-df3c3e1d0806"
+					"host": "test-route-host",
+					"relationships": {
+						"space": {
+							"data": {
+								"guid": "0c78dd5d-c723-4f2e-b168-df3c3e1d0806"
+							}
 						}
 					}
-				}
-			}`)
+				}`)
 			})
 
-			It("returns a status 422 Unprocessable Entity", func() {
-				Expect(rr.Code).To(Equal(http.StatusUnprocessableEntity), "Matching HTTP response code:")
-			})
-
-			It("returns Content-Type as JSON in header", func() {
-				contentTypeHeader := rr.Header().Get("Content-Type")
-				Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
-			})
-
-			It("has the expected error response body", func() {
-				Expect(rr.Body.String()).To(MatchJSON(`{
-				 "errors": [
-					{
-						"title": "CF-UnprocessableEntity",
-						"detail": "Data is a required field",
-						"code": 10008
-					}
-				]
-			}`), "Response body matches response:")
-			})
+			itRespondsWithUnprocessableEntity("Data is a required field", getRR)
 		})
 
 		When("the request body is missing the space relationship", func() {
 			BeforeEach(func() {
 				makePostRequest(`{
-				"host": "test-route-host",
-				"relationships": {
-					"domain": {
-						"data": {
-							"guid": "0b78dd5d-c723-4f2e-b168-df3c3e1d0806"
+					"host": "test-route-host",
+					"relationships": {
+						"domain": {
+							"data": {
+								"guid": "0b78dd5d-c723-4f2e-b168-df3c3e1d0806"
+							}
 						}
 					}
-				}
-			}`)
+				}`)
 			})
 
-			It("returns a status 422 Unprocessable Entity", func() {
-				Expect(rr.Code).To(Equal(http.StatusUnprocessableEntity), "Matching HTTP response code:")
-			})
-
-			It("returns Content-Type as JSON in header", func() {
-				contentTypeHeader := rr.Header().Get("Content-Type")
-				Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
-			})
-
-			It("has the expected error response body", func() {
-				Expect(rr.Body.String()).To(MatchJSON(`{
-				 "errors": [
-					{
-						"title": "CF-UnprocessableEntity",
-						"detail": "Data is a required field",
-						"code": 10008
-					}
-				]
-			}`), "Response body matches response:")
-			})
+			itRespondsWithUnprocessableEntity("Data is a required field", getRR)
 		})
 
 		When("the client cannot be built", func() {
@@ -707,26 +573,10 @@ var _ = Describe("RouteHandler", func() {
 				makePostRequest(requestBody)
 			})
 
-			It("returns a status 422 Unprocessable Entity", func() {
-				Expect(rr.Code).To(Equal(http.StatusUnprocessableEntity), "Matching HTTP response code:")
-			})
-
-			It("returns Content-Type as JSON in header", func() {
-				contentTypeHeader := rr.Header().Get("Content-Type")
-				Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
-			})
-
-			It("returns a CF API formatted Error response", func() {
-				Expect(rr.Body.String()).To(MatchJSON(`{
-				 "errors": [
-					{
-						"title": "CF-UnprocessableEntity",
-						"detail": "Invalid space. Ensure that the space exists and you have access to it.",
-						"code": 10008
-					}
-				]
-			}`), "Response body matches response:")
-			})
+			itRespondsWithUnprocessableEntity(
+				"Invalid space. Ensure that the space exists and you have access to it.",
+				getRR,
+			)
 		})
 
 		When("FetchNamespace returns an unknown error", func() {
@@ -754,26 +604,10 @@ var _ = Describe("RouteHandler", func() {
 				makePostRequest(requestBody)
 			})
 
-			It("returns a status 422 Unprocessable Entity", func() {
-				Expect(rr.Code).Should(Equal(http.StatusUnprocessableEntity), "Matching HTTP response code:")
-			})
-
-			It("returns Content-Type as JSON in header", func() {
-				contentTypeHeader := rr.Header().Get("Content-Type")
-				Expect(contentTypeHeader).Should(Equal(jsonHeader), "Matching Content-Type header:")
-			})
-
-			It("returns a CF API formatted Error response", func() {
-				Expect(rr.Body.String()).Should(MatchJSON(`{
-				 "errors": [
-					{
-						"title": "CF-UnprocessableEntity",
-						"detail": "Invalid domain. Ensure that the domain exists and you have access to it.",
-						"code": 10008
-					}
-				]
-			}`), "Response body matches response:")
-			})
+			itRespondsWithUnprocessableEntity(
+				"Invalid domain. Ensure that the domain exists and you have access to it.",
+				getRR,
+			)
 		})
 
 		When("FetchDomain returns an unknown error", func() {

--- a/docs/api.md
+++ b/docs/api.md
@@ -36,7 +36,8 @@ Docs: https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#apps
 |--|--|
 | List Apps | GET /v3/apps |
 | Get App | GET /v3/apps/\<guid> |
-| Create App | POST /v3/apps
+| Create App | POST /v3/apps |
+| Set App's Current Droplet | PATCH /v3/apps/\<guid>/current_droplet |
 
 #### [Creating Apps](https://v3-apidocs.cloudfoundry.org/version/3.100.0/index.html#the-app-object)
 Note : `namespace` needs to exist before creating the app.
@@ -44,6 +45,13 @@ Note : `namespace` needs to exist before creating the app.
 curl "http://localhost:9000/v3/apps" \
   -X POST \
   -d '{"name":"my-app","relationships":{"space":{"data":{"guid":"<namespace-name>"}}}}'
+```
+
+#### [Setting App's Current Droplet](https://v3-apidocs.cloudfoundry.org/version/3.108.0/index.html#update-a-droplet)
+```bash
+curl "http://localhost:9000/v3/apps/<app-guid>/relationships/current_droplet" \
+  -X PATCH \
+  -d '{"data":{"guid":"<droplet-guid>"}}'
 ```
 
 ### Packages

--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ func main() {
 			ctrl.Log.WithName("AppHandler"),
 			config.ServerURL,
 			new(repositories.AppRepo),
+			new(repositories.DropletRepo),
 			repositories.BuildCRClient,
 			k8sClientConfig,
 		),

--- a/payloads/app.go
+++ b/payloads/app.go
@@ -49,3 +49,7 @@ func (p AppCreate) ToRecord() repositories.AppRecord {
 		UpdatedAt:   "",
 	}
 }
+
+type AppSetCurrentDroplet struct {
+	Relationship `json:",inline" validate:"required"`
+}

--- a/presenter/app.go
+++ b/presenter/app.go
@@ -133,3 +133,31 @@ func ForAppList(appRecordList []repositories.AppRecord, baseURL string) AppListR
 
 	return appListResponse
 }
+
+type CurrentDropletResponse struct {
+	Relationship `json:",inline"`
+	Links        CurrentDropletLinks `json:"links"`
+}
+
+type CurrentDropletLinks struct {
+	Self    Link `json:"self"`
+	Related Link `json:"related"`
+}
+
+func ForCurrentDroplet(record repositories.CurrentDropletRecord, baseURL string) CurrentDropletResponse {
+	return CurrentDropletResponse{
+		Relationship: Relationship{
+			Data: RelationshipData{
+				GUID: record.DropletGUID,
+			},
+		},
+		Links: CurrentDropletLinks{
+			Self: Link{
+				HREF: prefixedLinkURL(baseURL, fmt.Sprintf("v3/apps/%s/relationships/current_droplet", record.AppGUID)),
+			},
+			Related: Link{
+				HREF: prefixedLinkURL(baseURL, fmt.Sprintf("v3/apps/%s/droplets/current", record.AppGUID)),
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Is there a related GitHub Issue?
#55 

## What is this change about?
It adds the PATCH `/v3/apps/:guid/current_droplet` endpoint and supporting code. It also introduces some test helpers for the UnprocessableEntity case

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Follow the AC in the issue

## Tag your pair, your PM, and/or team
@gnovv paired with me