### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
This PR adds a dependabot config so that we get PRs to keep our go.mod dependency versions up to date.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
We should start getting dependabot PRs to bump Go dependency versions.