### PR TITLE
Fix Package Upload State

### DIFF
--- a/apis/package_handler.go
+++ b/apis/package_handler.go
@@ -9,19 +9,15 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"code.cloudfoundry.org/cf-k8s-api/payloads"
+	"code.cloudfoundry.org/cf-k8s-api/presenter"
+	"code.cloudfoundry.org/cf-k8s-api/repositories"
 
 	"github.com/go-logr/logr"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/gorilla/mux"
-
-	"code.cloudfoundry.org/cf-k8s-api/payloads"
-
-	"code.cloudfoundry.org/cf-k8s-api/presenter"
-
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"code.cloudfoundry.org/cf-k8s-api/repositories"
 )
 
 const (
@@ -164,6 +160,12 @@ func (h PackageHandler) packageUploadHandler(w http.ResponseWriter, req *http.Re
 			h.logger.Info("Error fetching package with repository", "error", err.Error())
 			writeUnknownErrorResponse(w)
 		}
+		return
+	}
+
+	if record.State != repositories.PackageStateAwaitingUpload {
+		h.logger.Info("Error, cannot call package upload state was not AWAITING_UPLOAD", "packageGUID", packageGUID)
+		writePackageBitsAlreadyUploadedError(w)
 		return
 	}
 

--- a/apis/shared.go
+++ b/apis/shared.go
@@ -145,6 +145,14 @@ func newInvalidRequestError(detail string) presenter.ErrorsResponse {
 	}}}
 }
 
+func newPackageBitsAlreadyUploadedError() presenter.ErrorsResponse {
+	return presenter.ErrorsResponse{Errors: []presenter.PresentedError{{
+		Title:  "CF-PackageBitsAlreadyUploaded",
+		Detail: "Bits may be uploaded only once. Create a new package to upload different bits.",
+		Code:   150004,
+	}}}
+}
+
 func writeNotFoundErrorResponse(w http.ResponseWriter, resourceName string) {
 	responseBody, err := json.Marshal(newNotFoundError(resourceName))
 	if err != nil {
@@ -195,6 +203,16 @@ func writeInvalidRequestError(w http.ResponseWriter, detail string) {
 	w.WriteHeader(http.StatusBadRequest)
 
 	responseBody, err := json.Marshal(newInvalidRequestError(detail))
+	if err != nil {
+		return
+	}
+	w.Write(responseBody)
+}
+
+func writePackageBitsAlreadyUploadedError(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusBadRequest)
+
+	responseBody, err := json.Marshal(newPackageBitsAlreadyUploadedError())
 	if err != nil {
 		return
 	}

--- a/docs/api.md
+++ b/docs/api.md
@@ -70,7 +70,7 @@ curl "http://localhost:9000/v3/packages" \
 
 #### [Uploading Package Bits](https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#upload-package-bits)
 ```bash
-curl "http://api-shim.example.org/v3/packages/<guid>/upload" \
+curl "http://localhost:9000/v3/packages/<guid>/upload" \
   -X POST \
   -F bits=@"<path-to-app-source.zip>"
 ```

--- a/repositories/package_repository.go
+++ b/repositories/package_repository.go
@@ -15,6 +15,9 @@ import (
 
 const (
 	kind = "CFPackage"
+
+	PackageStateAwaitingUpload = "AWAITING_UPLOAD"
+	PackageStateReady          = "READY"
 )
 
 //+kubebuilder:rbac:groups=workloads.cloudfoundry.org,resources=cfpackages,verbs=get;list;watch;create;update;patch;delete
@@ -111,9 +114,9 @@ func packageCreateToCFPackage(message PackageCreateMessage) workloadsv1alpha1.CF
 
 func cfPackageToPackageRecord(cfPackage workloadsv1alpha1.CFPackage) PackageRecord {
 	updatedAtTime, _ := getTimeLastUpdatedTimestamp(&cfPackage.ObjectMeta)
-	state := "AWAITING_UPLOAD"
+	state := PackageStateAwaitingUpload
 	if cfPackage.Spec.Source.Registry.Image != "" {
-		state = "PROCESSING_UPLOAD"
+		state = PackageStateReady
 	}
 	return PackageRecord{
 		GUID:      cfPackage.ObjectMeta.Name,

--- a/repositories/package_repository_test.go
+++ b/repositories/package_repository_test.go
@@ -220,7 +220,7 @@ var _ = Describe("PackageRepository", func() {
 				},
 				{
 					description:   "an source image is set",
-					expectedState: "PROCESSING_UPLOAD",
+					expectedState: "READY",
 					setupFunc:     func(p *workloadsv1alpha1.CFPackage) { p.Spec.Source.Registry.Image = "some-org/some-repo" },
 				},
 			}
@@ -374,7 +374,7 @@ var _ = Describe("PackageRepository", func() {
 			Expect(returnedPackageRecord.Type).To(Equal(string(existingCFPackage.Spec.Type)))
 			Expect(returnedPackageRecord.AppGUID).To(Equal(existingCFPackage.Spec.AppRef.Name))
 			Expect(returnedPackageRecord.SpaceGUID).To(Equal(existingCFPackage.ObjectMeta.Namespace))
-			Expect(returnedPackageRecord.State).To(Equal("PROCESSING_UPLOAD"))
+			Expect(returnedPackageRecord.State).To(Equal("READY"))
 
 			createdAt, err := time.Parse(time.RFC3339, returnedPackageRecord.CreatedAt)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Is there a related GitHub Issue?
resolves https://github.com/cloudfoundry/cf-k8s-api/issues/142

## What is this change about?
Package upload api - Set state to READY and handle bits_already_uploaded case
- also fixed typo in README

## Does this PR introduce a breaking change?
no

## Acceptance Steps
Follow README instructions to run API Shim
create an App and Package
Upload bits
```
curl "http://localhost:9000/v3/packages/28dcc8d9-cb0e-448c-b3b4-1539bf58e4dd/upload"   -X POST   -F bits=@"spring-petclinic.zip"
```
Confirm that output reads `"state": "READY"`

Try to re-upload bits to the same package:
```
curl "http://localhost:9000/v3/packages/28dcc8d9-cb0e-448c-b3b4-1539bf58e4dd/upload"   -X POST   -F bits=@"spring-petclinic.zip"
{"errors":[{"detail":"Bits may be uploaded only once. Create a new package to upload different bits.","title":"CF-PackageBitsAlreadyUploaded","code":150004}]}
```
