### PR TITLE
Run tests with ./scripts/test in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,17 +24,11 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: fmt vet ## Run tests.
-	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out -shuffle on
+	./scripts/test
 
-test-e2e: ginkgo
-ifndef SKIP_DEPLOY
-	./scripts/deploy-on-kind.sh e2e
-endif
-	KUBECONFIG="${HOME}/.kube/e2e.yml" API_SERVER_ROOT=http://localhost ROOT_NAMESPACE=cf-k8s-api-system $(GINKGO) -p -randomizeAllSpecs -randomizeSuites -keepGoing -slowSpecThreshold 30 -tags e2e tests/e2e
+test-e2e:
+	./scripts/test tests/e2e
 
 run: fmt vet ## Run a controller from your host.
 	go run ./main.go

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+ENVTEST_ASSETS_DIR=$SCRIPT_DIR/../testbin
+mkdir -p $ENVTEST_ASSETS_DIR
+
+go install github.com/onsi/ginkgo/ginkgo@latest
+
+extra_args=()
+if ! egrep -q e2e <(echo "$@"); then
+  test -f $ENVTEST_ASSETS_DIR/setup-envtest.sh || curl -sSLo $ENVTEST_ASSETS_DIR/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
+  source $ENVTEST_ASSETS_DIR/setup-envtest.sh
+  fetch_envtest_tools $ENVTEST_ASSETS_DIR
+  setup_envtest_env $ENVTEST_ASSETS_DIR
+  extra_args+=("-skipPackage=test")
+else
+  if [ -z "$SKIP_DEPLOY" ]; then
+    ./scripts/deploy-on-kind.sh e2e
+  fi
+
+  export KUBECONFIG="${HOME}/.kube/e2e.yml"
+  export API_SERVER_ROOT=http://localhost
+  export ROOT_NAMESPACE=cf-k8s-api-system
+fi
+
+ginkgo -r -p -coverprofile cover.out -randomizeSuites -randomizeAllSpecs "${extra_args[@]}" $@

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package e2e_test
 
 import (

--- a/tests/e2e/orgs_test.go
+++ b/tests/e2e/orgs_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package e2e_test
 
 import (

--- a/tests/e2e/spaces_test.go
+++ b/tests/e2e/spaces_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package e2e_test
 
 import (


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

# What is this change about?
* the test script uses ginkgo instead of go test
* the build tags are removed, since ginkgo does not care about them and
  will try (and fail) to build the package
* use `-skipPackage=tests` to prevent e2e tests running with the rest of
  the test suites
* the script is useful for running individual suites, for example:
  `./script/test handler`
* move the ginkgo installation and envtest setup from the Makefile to
  the script

## Does this PR introduce a breaking change?
No

## Acceptance Steps
* `make test` and `make test-e2e` should work as before
* `script/test <directory>` should only run tests in that directory
* `script/test` runs all non-e2e tests
* `script/test tests/e2e` runs e2e tests

## Tag your pair, your PM, and/or team
@mnitchev 
