### PR TITLE
Add phony make target for pushing docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SHELL = /usr/bin/env bash -o pipefail
 
 .DEFAULT_GOAL := test
 
-.PHONY: hnc-install test test-e2e kustomize docker-build fmt vet
+.PHONY: hnc-install test test-e2e kustomize docker-build docker-push fmt vet
 
 fmt: ## Run go fmt against code.
 	go fmt ./...
@@ -52,6 +52,9 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 docker-build: ## Build docker image with the manager.
 	docker build -t ${IMG} .
+
+docker-push: ## Push docker image with the manager.
+	docker push ${IMG}
 
 build-reference: kustomize
 	cd config/base && $(KUSTOMIZE) edit set image cloudfoundry/cf-k8s-api=${IMG}


### PR DESCRIPTION
## Is there a related GitHub Issue?
No.

## What is this change about?
Adding a make target for `docker-push` mirroring `cf-k8s-controllers` and standard kubebuilder projects.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Run `make docker-push` after running `make docker-build`.

## Tag your pair, your PM, and/or team
@PureMunky - should help with testing changes.