### PR TITLE
Deploy eirini on kind

### DIFF
--- a/.github/workflows/test-build-push-main.yml
+++ b/.github/workflows/test-build-push-main.yml
@@ -49,6 +49,10 @@ jobs:
         with:
           repository: cloudfoundry/cf-k8s-controllers
           path: cf-k8s-controllers
+      - uses: actions/checkout@v2
+        with:
+          repository: cloudfoundry-incubator/eirini-controller
+          path: eirini-controller
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -49,6 +49,10 @@ jobs:
         with:
           repository: cloudfoundry/cf-k8s-controllers
           path: cf-k8s-controllers
+      - uses: actions/checkout@v2
+        with:
+          repository: cloudfoundry-incubator/eirini-controller
+          path: eirini-controller
       - uses: actions/cache@v2
         with:
           path: |

--- a/scripts/assets/eirini-controller-kbld.yml
+++ b/scripts/assets/eirini-controller-kbld.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+searchRules:
+- keyMatcher:
+    path: [images, eirini_controller]
+sources:
+- image: eirini/eirini-controller
+  path: .
+  docker:
+    build:
+      file: docker/eirini-controller/Dockerfile
+      rawOptions: ["--build-arg", "GIT_SHA=eirini-controller-dirty", "--tag", "eirini-controller"]
+      buildkit: true

--- a/scripts/install-hnc.sh
+++ b/scripts/install-hnc.sh
@@ -42,3 +42,7 @@ until kubectl delete namespace ping-hnc --wait=false; do
   sleep 0.5
 done
 echo
+
+# The eirini controller requires a service account and rolebinding, which are
+# used by the statefulset controller to be able to create pods
+kubectl hns config set-resource serviceaccounts --mode Propagate


### PR DESCRIPTION
## Is there a related GitHub Issue?

Yes: cloudfoundry/cf-k8s-controllers#109

## What is this change about?
This change deploys eirini in the deploy on kind script. Additionally:
* the eirini controller templates will create a "default" namespace,
  which is intended to be the root namespace for hns. The templates also
  include the necassary rbac, which will be propagated to the child
  namespaces.
* configure service account propagation for hns. This is necessary as
  the workloads namepsaces require a service account and rolebinding for
  the StatefulSet controller to be able to create pods
* in order to propagate the rbac *only* to the "spaces" subnamespaces,
  we need a change in eirini, which introduces additinal annotations to
  the workloads namespaces rbac resources. This can also be done with a
  ytt overlay. The annotation necessary is described here:
  https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/master/docs/user-guide/how-to.md#limit-the-propagation-of-an-object-to-descendant-namespaces

## Does this PR introduce a breaking change?
No

## Acceptance Steps
1. Run ` ./scripts/deploy-on-kind.sh e2e`
1. Notice that eirini-controller is up and running in the `eirini-controller-system` namespace
1. *Optionally* create subnamespaces using `kubectl hns create -n  cf <your-ns-name>`
1. Create an LRP using the following command:
```shell
cat <<EOF | kubectl apply -f -
apiVersion: eirini.cloudfoundry.org/v1
kind: LRP
metadata:
  name: mylrp
  namespace: <your-ns-name>
spec:
  GUID: $(uuidgen)
  diskMB: 256
  image: eirini/dorini
EOF
```
## Tag your pair, your PM, and/or team
@danail-branekov 

