### PR TITLE
Run tests in container for GitHub Actions

### DIFF
--- a/.github/workflows/test-build-push-main.yml
+++ b/.github/workflows/test-build-push-main.yml
@@ -20,6 +20,7 @@ jobs:
   unit-tests:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    container: ghcr.io/cloudfoundry/cf-k8s-api-ci
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -42,6 +43,7 @@ jobs:
   e2e-tests:
     needs: unit-tests
     runs-on: ubuntu-latest
+    container: ghcr.io/cloudfoundry/cf-k8s-api-ci
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -33,6 +33,7 @@ jobs:
     needs: check-reference
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    container: ghcr.io/cloudfoundry/cf-k8s-api-ci
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -55,6 +56,7 @@ jobs:
   e2e-tests:
     needs: unit-tests
     runs-on: ubuntu-latest
+    container: ghcr.io/cloudfoundry/cf-k8s-api-ci
     steps:
       - uses: actions/checkout@v2
         with:

--- a/scripts/install-hnc.sh
+++ b/scripts/install-hnc.sh
@@ -7,9 +7,11 @@ readonly HNC_PLATFORM="$(go env GOHOSTOS)_$(go env GOHOSTARCH)"
 readonly HNC_BIN="$PWD/bin"
 export PATH="$HNC_BIN:$PATH"
 
-mkdir -p "$HNC_BIN"
-curl -L "https://github.com/kubernetes-sigs/multi-tenancy/releases/download/hnc-${HNC_VERSION}/kubectl-hns_${HNC_PLATFORM}" -o "${HNC_BIN}/kubectl-hns"
-chmod +x "${HNC_BIN}/kubectl-hns"
+if ! command -v kubectl-hns >/dev/null; then
+  mkdir -p "$HNC_BIN"
+  curl -L "https://github.com/kubernetes-sigs/multi-tenancy/releases/download/hnc-${HNC_VERSION}/kubectl-hns_${HNC_PLATFORM}" -o "${HNC_BIN}/kubectl-hns"
+  chmod +x "${HNC_BIN}/kubectl-hns"
+fi
 
 kubectl label ns kube-system hnc.x-k8s.io/excluded-namespace=true --overwrite
 kubectl label ns kube-public hnc.x-k8s.io/excluded-namespace=true --overwrite

--- a/scripts/test
+++ b/scripts/test
@@ -7,7 +7,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ENVTEST_ASSETS_DIR=$SCRIPT_DIR/../testbin
 mkdir -p $ENVTEST_ASSETS_DIR
 
-go install github.com/onsi/ginkgo/ginkgo@latest
+if ! command -v ginkgo >/dev/null; then
+  go install github.com/onsi/ginkgo/ginkgo@latest
+fi
 
 extra_args=()
 if ! egrep -q e2e <(echo "$@"); then


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/cf-k8s-api/issues/176

## What is this change about?
We want to minimise the time it takes to run these tests. Because of
this we decided to installed binaries conditionally (if they are not
installed). This will retain the current behaviour for local
development. For GitHub actions all the tools will already be installed
in the ci image used for running tests.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
`make test`
`make e2e`
Both suites should succeed

## Tag your pair, your PM, and/or team
@cloudfoundry/eirini 
