### PR TITLE
Use correct dockerfile to build ci image

### DIFF
--- a/.github/workflows/build-ci-image-pr.yml
+++ b/.github/workflows/build-ci-image-pr.yml
@@ -20,4 +20,5 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          file: ci/Dockerfile
           push: false

--- a/.github/workflows/push-ci-image-main.yml
+++ b/.github/workflows/push-ci-image-main.yml
@@ -31,5 +31,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          file: ci/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Changes the github actions workflows to use the correct dockerfile when building the CI image. We had forgotten to add the `file` parameter to the docker build action and it was building the default image in the root of the repository. 

## Does this PR introduce a breaking change?
No

## Acceptance Steps
PRs should now have passing checks

## Tag your pair, your PM, and/or team
@georgethebeatle 
