### PR TITLE
Trigger docker build workflows on definition change

### DIFF
--- a/.github/workflows/build-ci-image-pr.yml
+++ b/.github/workflows/build-ci-image-pr.yml
@@ -3,7 +3,9 @@ name: Build the CI Docker Image on PR
 on:
   pull_request:
     branches: [ main ]
-    paths: ['ci/Dockerfile']
+    paths:
+    - 'ci/Dockerfile'
+    - '.github/workflows/build-ci-image-pr.yml'
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/push-ci-image-main.yml
+++ b/.github/workflows/push-ci-image-main.yml
@@ -3,7 +3,9 @@ name: Build and Push the CI Docker Image
 on:
   push:
     branches: [ main ]
-    paths: ['ci/Dockerfile']
+    paths:
+    - 'ci/Dockerfile'
+    - '.github/workflows/push-ci-image-main.yml'
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Is there a related GitHub Issue?
No
## What is this change about?
Sometimes the workflow definition might change without
the Dockerfile changing, but the image still needs to be
buit

## Does this PR introduce a breaking change?
No

## Acceptance Steps
None (the ci image should be pushed by workflow)

## Tag your pair, your PM, and/or team
@mnitchev 