### PR TITLE
Install kind in ci docker image

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -29,5 +29,6 @@ RUN  curl -sL "https://github.com/vmware-tanzu/carvel-kapp/releases/download/$KA
 ARG GINKGO_VERSION=v1.16.5
 RUN go install "github.com/onsi/ginkgo/ginkgo@$GINKGO_VERSION" "github.com/onsi/gomega/...@$GINKGO_VERSION"
 
-# ARG KIND_VERSION=v0.11.1
-# RUN go install sigs.k8s.io/kind@$KIND_VERSION
+ARG KIND_VERSION=v0.11.1
+RUN curl -sL "https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64" -o /usr/local/bin/kind && \
+  chmod +x /usr/local/bin/kind


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/cf-k8s-api/issues/176

## What is this change about?
Install kind in ci docker image

## Does this PR introduce a breaking change?
No

## Acceptance Steps
`docker run ghcr.io/cloudfoundry/cf-k8s-api-ci kind` should not fail

## Tag your pair, your PM, and/or team
@cloudfoundry/eirini 
