### PR TITLE
Implemented GET v3/routes

### DIFF
--- a/apis/fake/cfroute_repository.go
+++ b/apis/fake/cfroute_repository.go
@@ -41,6 +41,20 @@ type CFRouteRepository struct {
 		result1 repositories.RouteRecord
 		result2 error
 	}
+	FetchRouteListStub        func(context.Context, client.Client) ([]repositories.RouteRecord, error)
+	fetchRouteListMutex       sync.RWMutex
+	fetchRouteListArgsForCall []struct {
+		arg1 context.Context
+		arg2 client.Client
+	}
+	fetchRouteListReturns struct {
+		result1 []repositories.RouteRecord
+		result2 error
+	}
+	fetchRouteListReturnsOnCall map[int]struct {
+		result1 []repositories.RouteRecord
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -177,6 +191,71 @@ func (fake *CFRouteRepository) FetchRouteReturnsOnCall(i int, result1 repositori
 	}{result1, result2}
 }
 
+func (fake *CFRouteRepository) FetchRouteList(arg1 context.Context, arg2 client.Client) ([]repositories.RouteRecord, error) {
+	fake.fetchRouteListMutex.Lock()
+	ret, specificReturn := fake.fetchRouteListReturnsOnCall[len(fake.fetchRouteListArgsForCall)]
+	fake.fetchRouteListArgsForCall = append(fake.fetchRouteListArgsForCall, struct {
+		arg1 context.Context
+		arg2 client.Client
+	}{arg1, arg2})
+	stub := fake.FetchRouteListStub
+	fakeReturns := fake.fetchRouteListReturns
+	fake.recordInvocation("FetchRouteList", []interface{}{arg1, arg2})
+	fake.fetchRouteListMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *CFRouteRepository) FetchRouteListCallCount() int {
+	fake.fetchRouteListMutex.RLock()
+	defer fake.fetchRouteListMutex.RUnlock()
+	return len(fake.fetchRouteListArgsForCall)
+}
+
+func (fake *CFRouteRepository) FetchRouteListCalls(stub func(context.Context, client.Client) ([]repositories.RouteRecord, error)) {
+	fake.fetchRouteListMutex.Lock()
+	defer fake.fetchRouteListMutex.Unlock()
+	fake.FetchRouteListStub = stub
+}
+
+func (fake *CFRouteRepository) FetchRouteListArgsForCall(i int) (context.Context, client.Client) {
+	fake.fetchRouteListMutex.RLock()
+	defer fake.fetchRouteListMutex.RUnlock()
+	argsForCall := fake.fetchRouteListArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *CFRouteRepository) FetchRouteListReturns(result1 []repositories.RouteRecord, result2 error) {
+	fake.fetchRouteListMutex.Lock()
+	defer fake.fetchRouteListMutex.Unlock()
+	fake.FetchRouteListStub = nil
+	fake.fetchRouteListReturns = struct {
+		result1 []repositories.RouteRecord
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CFRouteRepository) FetchRouteListReturnsOnCall(i int, result1 []repositories.RouteRecord, result2 error) {
+	fake.fetchRouteListMutex.Lock()
+	defer fake.fetchRouteListMutex.Unlock()
+	fake.FetchRouteListStub = nil
+	if fake.fetchRouteListReturnsOnCall == nil {
+		fake.fetchRouteListReturnsOnCall = make(map[int]struct {
+			result1 []repositories.RouteRecord
+			result2 error
+		})
+	}
+	fake.fetchRouteListReturnsOnCall[i] = struct {
+		result1 []repositories.RouteRecord
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *CFRouteRepository) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -184,6 +263,8 @@ func (fake *CFRouteRepository) Invocations() map[string][][]interface{} {
 	defer fake.createRouteMutex.RUnlock()
 	fake.fetchRouteMutex.RLock()
 	defer fake.fetchRouteMutex.RUnlock()
+	fake.fetchRouteListMutex.RLock()
+	defer fake.fetchRouteListMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/docs/api.md
+++ b/docs/api.md
@@ -124,6 +124,7 @@ Docs: https://v3-apidocs.cloudfoundry.org/version/3.100.0/index.html#processes
 | Resource | Endpoint |
 |--|--|
 | Get Route | GET /v3/routes/\<guid> |
+| Get Route List | GET /v3/routes |
 | Get Route Destinations | GET /v3/routes/\<guid>\destinations |
 | Create Route | POST /v3/routes |
 

--- a/repositories/route_repository.go
+++ b/repositories/route_repository.go
@@ -50,7 +50,19 @@ func (f *RouteRepo) FetchRoute(ctx context.Context, client client.Client, routeG
 	routeList := cfRouteList.Items
 	filteredRouteList := f.filterByRouteName(routeList, routeGUID)
 
-	return f.returnRoute(filteredRouteList)
+	toReturn, err := f.returnRoute(filteredRouteList)
+	return toReturn, err
+}
+
+func (f *RouteRepo) FetchRouteList(ctx context.Context, client client.Client) ([]RouteRecord, error) {
+	cfRouteList := &networkingv1alpha1.CFRouteList{}
+	err := client.List(ctx, cfRouteList)
+
+	if err != nil {
+		return []RouteRecord{}, err
+	}
+
+	return f.returnRouteList(cfRouteList.Items), nil
 }
 
 func (r RouteRecord) UpdateDomainRef(d DomainRecord) RouteRecord {
@@ -81,6 +93,15 @@ func (f *RouteRepo) returnRoute(routeList []networkingv1alpha1.CFRoute) (RouteRe
 	}
 
 	return cfRouteToRouteRecord(routeList[0]), nil
+}
+
+func (f *RouteRepo) returnRouteList(routeList []networkingv1alpha1.CFRoute) []RouteRecord {
+	routeRecords := make([]RouteRecord, 0, len(routeList))
+
+	for _, route := range routeList {
+		routeRecords = append(routeRecords, cfRouteToRouteRecord(route))
+	}
+	return routeRecords
 }
 
 func cfRouteToRouteRecord(cfRoute networkingv1alpha1.CFRoute) RouteRecord {

--- a/repositories/route_repository_test.go
+++ b/repositories/route_repository_test.go
@@ -184,6 +184,191 @@ var _ = Describe("RouteRepository", func() {
 		})
 	})
 
+	Describe("GetRouteList", func() {
+		var (
+			testCtx context.Context
+
+			routeRepo  RouteRepo
+			repoClient client.Client
+		)
+
+		BeforeEach(func() {
+			testCtx = context.Background()
+
+			routeRepo = RouteRepo{}
+			var err error
+			repoClient, err = BuildCRClient(k8sConfig)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		When("multiple CFRoutes exist", func() {
+			var (
+				route1GUID string
+				route2GUID string
+				domainGUID string
+
+				cfRoute1 *networkingv1alpha1.CFRoute
+				cfRoute2 *networkingv1alpha1.CFRoute
+			)
+
+			BeforeEach(func() {
+				route1GUID = generateGUID()
+				route2GUID = generateGUID()
+				domainGUID = generateGUID()
+
+				ctx := context.Background()
+
+				cfRoute1 = &networkingv1alpha1.CFRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      route1GUID,
+						Namespace: "default",
+					},
+					Spec: networkingv1alpha1.CFRouteSpec{
+						Host:     "my-subdomain-1",
+						Path:     "",
+						Protocol: "http",
+						DomainRef: corev1.LocalObjectReference{
+							Name: domainGUID,
+						},
+						Destinations: []networkingv1alpha1.Destination{
+							{
+								GUID: "destination-guid",
+								Port: 8080,
+								AppRef: corev1.LocalObjectReference{
+									Name: "some-app-guid",
+								},
+								ProcessType: "web",
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, cfRoute1)).To(Succeed())
+
+				cfRoute2 = &networkingv1alpha1.CFRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      route2GUID,
+						Namespace: "default",
+					},
+					Spec: networkingv1alpha1.CFRouteSpec{
+						Host:     "my-subdomain-2",
+						Path:     "",
+						Protocol: "http",
+						DomainRef: corev1.LocalObjectReference{
+							Name: domainGUID,
+						},
+						Destinations: []networkingv1alpha1.Destination{},
+					},
+				}
+				Expect(k8sClient.Create(ctx, cfRoute2)).To(Succeed())
+			})
+
+			AfterEach(func() {
+				ctx := context.Background()
+				k8sClient.Delete(ctx, cfRoute1)
+				k8sClient.Delete(ctx, cfRoute2)
+			})
+
+			It("eventually returns a list of routeRecords for each CFRoute CR", func() {
+				var routeRecords []RouteRecord
+				Eventually(func() int {
+					routeRecords, _ = routeRepo.FetchRouteList(testCtx, repoClient)
+					return len(routeRecords)
+				}, timeCheckThreshold*time.Second).Should(Equal(2), "returned records count should equal number of created CRs")
+
+				By("returning a routeRecord in the list for one of the created CRs", func() {
+					var route RouteRecord
+					var found bool
+					for _, routeRecord := range routeRecords {
+						if routeRecord.GUID == cfRoute1.Name {
+							found = true
+							route = routeRecord
+							break
+						}
+					}
+					Expect(found).To(BeTrue(), "could not find matching record")
+
+					By("returning a record with metadata fields from the CFRoute CR", func() {
+						Expect(route.GUID).To(Equal(cfRoute1.Name))
+						Expect(route.Host).To(Equal(cfRoute1.Spec.Host))
+						Expect(route.SpaceGUID).To(Equal(cfRoute1.Namespace))
+					})
+
+					By("returning a record with spec fields from the CFRoute CR", func() {
+						Expect(route.Path).To(Equal(cfRoute1.Spec.Path))
+						Expect(route.Protocol).To(Equal(string(cfRoute1.Spec.Protocol)))
+						Expect(route.DomainRef.GUID).To(Equal(cfRoute1.Spec.DomainRef.Name))
+					})
+
+					By("returning a record with destinations that match the CFRoute CR", func() {
+						Expect(len(route.Destinations)).To(Equal(len(cfRoute1.Spec.Destinations)), "Route Record Destinations returned was not the correct length")
+						destinationRecord := route.Destinations[0]
+						Expect(destinationRecord.GUID).To(Equal(cfRoute1.Spec.Destinations[0].GUID))
+						Expect(destinationRecord.AppGUID).To(Equal(cfRoute1.Spec.Destinations[0].AppRef.Name))
+						Expect(destinationRecord.Port).To(Equal(cfRoute1.Spec.Destinations[0].Port))
+						Expect(destinationRecord.ProcessType).To(Equal(cfRoute1.Spec.Destinations[0].ProcessType))
+					})
+
+					By("returning a record where the CreatedAt and UpdatedAt match the CR creation time", func() {
+						createdAt, err := time.Parse(time.RFC3339, route.CreatedAt)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(createdAt).To(BeTemporally("~", time.Now(), timeCheckThreshold*time.Second))
+
+						updatedAt, err := time.Parse(time.RFC3339, route.CreatedAt)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(updatedAt).To(BeTemporally("~", time.Now(), timeCheckThreshold*time.Second))
+					})
+				})
+
+				By("returning a routeRecord in the list that matches another of the created CRs", func() {
+					var route RouteRecord
+					var found bool
+					for _, routeRecord := range routeRecords {
+						if routeRecord.GUID == cfRoute2.Name {
+							found = true
+							route = routeRecord
+							break
+						}
+					}
+					Expect(found).To(BeTrue(), "could not find matching record")
+
+					By("returning a record with metadata fields from the CFRoute CR", func() {
+						Expect(route.GUID).To(Equal(cfRoute2.Name))
+						Expect(route.Host).To(Equal(cfRoute2.Spec.Host))
+						Expect(route.SpaceGUID).To(Equal(cfRoute2.Namespace))
+					})
+
+					By("returning a record with spec fields from the CFRoute CR", func() {
+						Expect(route.Path).To(Equal(cfRoute2.Spec.Path))
+						Expect(route.Protocol).To(Equal(string(cfRoute2.Spec.Protocol)))
+						Expect(route.DomainRef.GUID).To(Equal(cfRoute2.Spec.DomainRef.Name))
+					})
+
+					By("returning a record with destinations that match the CFRoute CR", func() {
+						Expect(len(route.Destinations)).To(Equal(len(cfRoute2.Spec.Destinations)), "Route Record Destinations returned was not the correct length")
+					})
+
+					By("returning a record where the CreatedAt and UpdatedAt match the CR creation time", func() {
+						createdAt, err := time.Parse(time.RFC3339, route.CreatedAt)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(createdAt).To(BeTemporally("~", time.Now(), timeCheckThreshold*time.Second))
+
+						updatedAt, err := time.Parse(time.RFC3339, route.CreatedAt)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(updatedAt).To(BeTemporally("~", time.Now(), timeCheckThreshold*time.Second))
+					})
+				})
+			})
+		})
+
+		When("no CFRoutes exist", func() {
+			It("returns an empty list and no error", func() {
+				routeRecords, err := routeRepo.FetchRouteList(testCtx, repoClient)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(routeRecords).To(BeEmpty())
+			})
+		})
+	})
+
 	Describe("CreateRoute", func() {
 		const (
 			testNamespace = "default"


### PR DESCRIPTION
## Is there a related GitHub Issue?
resolves #87

## What is this change about?
Implement GET v3/destinations

## Does this PR introduce a breaking change?
no.

## Acceptance Steps
`make install` from controllers repo
`k apply -f config/samples/cfdomain.yaml`
`k apply -f config/samples/cfroute.yaml`

Follow README instructions to run APIShim
`curl http://localhost:9000/v3/destinations`
Delete the route CR and run the curl again