### PR TITLE
Write log output to GinkgoWriter

### DIFF
--- a/repositories/repositories_suite_test.go
+++ b/repositories/repositories_suite_test.go
@@ -1,7 +1,6 @@
 package repositories_test
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -36,7 +35,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(os.Stderr), zap.UseDevMode(true)))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
This means we don't see the envtest log output unless the test fails

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Run `scripts/test ./repositories`
Don't see lots of log output around successful tests.

## Tag your pair, your PM, and/or team
@danail-branekov 
