### PR TITLE
Implement create spaces (POST /v3/spaces)

### DIFF
--- a/apis/apis_suite_test.go
+++ b/apis/apis_suite_test.go
@@ -90,6 +90,18 @@ func expectUnprocessableEntityError(detail string) {
 		}`, detail))
 }
 
+func expectBadRequestError() {
+	expectJSONResponse(http.StatusBadRequest, `{
+        "errors": [
+            {
+                "title": "CF-MessageParseError",
+                "detail": "Request invalid due to parse error: invalid request body",
+                "code": 1001
+            }
+        ]
+    }`)
+}
+
 func initializeProcessRecord(processGUID, spaceGUID, appGUID string) *repositories.ProcessRecord {
 	return &repositories.ProcessRecord{
 		GUID:        processGUID,

--- a/apis/fake/cfspace_repository.go
+++ b/apis/fake/cfspace_repository.go
@@ -10,6 +10,20 @@ import (
 )
 
 type CFSpaceRepository struct {
+	CreateSpaceStub        func(context.Context, repositories.SpaceRecord) (repositories.SpaceRecord, error)
+	createSpaceMutex       sync.RWMutex
+	createSpaceArgsForCall []struct {
+		arg1 context.Context
+		arg2 repositories.SpaceRecord
+	}
+	createSpaceReturns struct {
+		result1 repositories.SpaceRecord
+		result2 error
+	}
+	createSpaceReturnsOnCall map[int]struct {
+		result1 repositories.SpaceRecord
+		result2 error
+	}
 	FetchSpacesStub        func(context.Context, []string, []string) ([]repositories.SpaceRecord, error)
 	fetchSpacesMutex       sync.RWMutex
 	fetchSpacesArgsForCall []struct {
@@ -27,6 +41,71 @@ type CFSpaceRepository struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *CFSpaceRepository) CreateSpace(arg1 context.Context, arg2 repositories.SpaceRecord) (repositories.SpaceRecord, error) {
+	fake.createSpaceMutex.Lock()
+	ret, specificReturn := fake.createSpaceReturnsOnCall[len(fake.createSpaceArgsForCall)]
+	fake.createSpaceArgsForCall = append(fake.createSpaceArgsForCall, struct {
+		arg1 context.Context
+		arg2 repositories.SpaceRecord
+	}{arg1, arg2})
+	stub := fake.CreateSpaceStub
+	fakeReturns := fake.createSpaceReturns
+	fake.recordInvocation("CreateSpace", []interface{}{arg1, arg2})
+	fake.createSpaceMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *CFSpaceRepository) CreateSpaceCallCount() int {
+	fake.createSpaceMutex.RLock()
+	defer fake.createSpaceMutex.RUnlock()
+	return len(fake.createSpaceArgsForCall)
+}
+
+func (fake *CFSpaceRepository) CreateSpaceCalls(stub func(context.Context, repositories.SpaceRecord) (repositories.SpaceRecord, error)) {
+	fake.createSpaceMutex.Lock()
+	defer fake.createSpaceMutex.Unlock()
+	fake.CreateSpaceStub = stub
+}
+
+func (fake *CFSpaceRepository) CreateSpaceArgsForCall(i int) (context.Context, repositories.SpaceRecord) {
+	fake.createSpaceMutex.RLock()
+	defer fake.createSpaceMutex.RUnlock()
+	argsForCall := fake.createSpaceArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *CFSpaceRepository) CreateSpaceReturns(result1 repositories.SpaceRecord, result2 error) {
+	fake.createSpaceMutex.Lock()
+	defer fake.createSpaceMutex.Unlock()
+	fake.CreateSpaceStub = nil
+	fake.createSpaceReturns = struct {
+		result1 repositories.SpaceRecord
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CFSpaceRepository) CreateSpaceReturnsOnCall(i int, result1 repositories.SpaceRecord, result2 error) {
+	fake.createSpaceMutex.Lock()
+	defer fake.createSpaceMutex.Unlock()
+	fake.CreateSpaceStub = nil
+	if fake.createSpaceReturnsOnCall == nil {
+		fake.createSpaceReturnsOnCall = make(map[int]struct {
+			result1 repositories.SpaceRecord
+			result2 error
+		})
+	}
+	fake.createSpaceReturnsOnCall[i] = struct {
+		result1 repositories.SpaceRecord
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *CFSpaceRepository) FetchSpaces(arg1 context.Context, arg2 []string, arg3 []string) ([]repositories.SpaceRecord, error) {
@@ -108,6 +187,8 @@ func (fake *CFSpaceRepository) FetchSpacesReturnsOnCall(i int, result1 []reposit
 func (fake *CFSpaceRepository) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.createSpaceMutex.RLock()
+	defer fake.createSpaceMutex.RUnlock()
 	fake.fetchSpacesMutex.RLock()
 	defer fake.fetchSpacesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/apis/org_handler_test.go
+++ b/apis/org_handler_test.go
@@ -85,26 +85,21 @@ var _ = Describe("OrgHandler", func() {
 				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
 				Expect(rr).To(HaveHTTPBody(MatchJSON(fmt.Sprintf(`{
                     "guid": "t-h-e-o-r-g",
-                    "name": "the-org",
-                    "created_at": "2021-09-17T15:23:10Z",
-                    "updated_at": "2021-09-17T15:23:10Z",
-                    "suspended": false,
-                    "metadata": {
-                        "labels": {},
-                        "annotations": {}
-                    },
-                    "relationships": {},
-                    "links": {
-                        "self": {
-                            "href": "%[1]s/v3/organizations/t-h-e-o-r-g"
-                        }
-                    }
-                }`, defaultServerURL))))
-			})
-
-			It("creates org repository for the request", func() {
-				Expect(orgRepoProvider.OrgRepoForRequestCallCount()).To(Equal(1))
-				Expect(orgRepoProvider.OrgRepoForRequestArgsForCall(0).Method).To(Equal(http.MethodPost))
+					"name": "the-org",
+					"created_at": "2021-09-17T15:23:10Z",
+					"updated_at": "2021-09-17T15:23:10Z",
+					"suspended": false,
+					"metadata": {
+					  "labels": {},
+					  "annotations": {}
+					},
+					"relationships": {},
+					"links": {
+						"self": {
+							"href": "%[1]s/v3/organizations/t-h-e-o-r-g"
+						}
+					}
+				}`, defaultServerURL))))
 			})
 
 			It("invokes the repo org create function with expected parameters", func() {

--- a/apis/space_handler_test.go
+++ b/apis/space_handler_test.go
@@ -4,29 +4,179 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"code.cloudfoundry.org/cf-k8s-api/apis"
 	"code.cloudfoundry.org/cf-k8s-api/apis/fake"
 	"code.cloudfoundry.org/cf-k8s-api/repositories"
+	"code.cloudfoundry.org/cf-k8s-controllers/webhooks/workloads"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Spaces", func() {
-	Describe("Listing Spaces", func() {
-		const spacesBase = "/v3/spaces"
-		var (
-			spaceHandler *apis.SpaceHandler
-			spaceRepo    *fake.CFSpaceRepository
-			err          error
-			now          time.Time
-		)
+	const spacesBase = "/v3/spaces"
 
+	var (
+		now           time.Time
+		spaceHandler  *apis.SpaceHandler
+		spaceRepo     *fake.CFSpaceRepository
+		requestMethod string
+		requestBody   string
+		requestPath   string
+	)
+
+	BeforeEach(func() {
+		now = time.Unix(1631892190, 0) // 2021-09-17T15:23:10Z
+		requestBody = ""
+		requestPath = spacesBase
+		spaceRepo = new(fake.CFSpaceRepository)
+		spaceHandler = apis.NewSpaceHandler(spaceRepo, *serverURL)
+		spaceHandler.RegisterRoutes(router)
+	})
+
+	JustBeforeEach(func() {
+		req, err := http.NewRequestWithContext(ctx, requestMethod, requestPath, strings.NewReader(requestBody))
+		Expect(err).NotTo(HaveOccurred())
+
+		router.ServeHTTP(rr, req)
+	})
+
+	Describe("Create Space", func() {
 		BeforeEach(func() {
-			spaceRepo = new(fake.CFSpaceRepository)
+			requestMethod = http.MethodPost
 
-			now = time.Unix(1631892190, 0) // 2021-09-17T15:23:10Z
+			spaceRepo.CreateSpaceReturns(repositories.SpaceRecord{
+				Name:             "the-space",
+				GUID:             "t-h-e-s-p-a-c-e",
+				OrganizationGUID: "the-org",
+				CreatedAt:        now,
+				UpdatedAt:        now,
+			}, nil)
+
+			requestBody = `{
+                "name": "the-space",
+                "relationships": {
+                    "organization": {
+                        "data": {
+                            "guid": "[org-guid]"
+                        }
+                    }
+                }
+            }`
+		})
+
+		It("returns 201 with appropriate success JSON", func() {
+			Expect(rr).To(HaveHTTPStatus(http.StatusCreated))
+			Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+			Expect(rr).To(HaveHTTPBody(MatchJSON(fmt.Sprintf(`{
+                "guid": "t-h-e-s-p-a-c-e",
+                "name": "the-space",
+                "created_at": "2021-09-17T15:23:10Z",
+                "updated_at": "2021-09-17T15:23:10Z",
+                "metadata": {
+                    "labels": {},
+                    "annotations": {}
+                },
+                "relationships": {
+                    "organization": {
+                        "data": {
+                            "guid": "the-org"
+                        }
+                    }
+                },
+                "links": {
+                    "self": {
+                        "href": "%[1]s/v3/spaces/t-h-e-s-p-a-c-e"
+                    },
+                    "organization": {
+                        "href": "%[1]s/v3/organizations/the-org"
+                    }
+                }
+            }`, defaultServerURL))))
+		})
+
+		It("uses the space repo to create the space", func() {
+			Expect(spaceRepo.CreateSpaceCallCount()).To(Equal(1))
+			_, spaceRecord := spaceRepo.CreateSpaceArgsForCall(0)
+			Expect(spaceRecord.Name).To(Equal("the-space"))
+		})
+
+		When("a field in the request has invalid value", func() {
+			BeforeEach(func() {
+				requestBody = `{
+                    "name": 123,
+                    "relationships": {
+                        "organization": {
+                            "data": {
+                                "guid": "[org-guid]"
+                            }
+                        }
+                    }
+                }`
+			})
+
+			It("returns a bad request error", func() {
+				expectUnprocessableEntityError("Name must be a string")
+			})
+		})
+
+		When("the request body is invalid json", func() {
+			BeforeEach(func() {
+				requestBody = `{"definitely not valid json`
+			})
+
+			It("returns a bad request error", func() {
+				expectBadRequestError()
+			})
+		})
+
+		When("when a required field is not provided", func() {
+			BeforeEach(func() {
+				requestBody = `{
+                    "name": "the-name",
+                    "relationships": {
+                    }
+                }`
+			})
+
+			It("returns a bad request error", func() {
+				expectUnprocessableEntityError("Data is a required field")
+			})
+		})
+
+		When("the space repo returns a uniqueness error", func() {
+			BeforeEach(func() {
+				var err error = &k8serrors.StatusError{
+					ErrStatus: metav1.Status{
+						Reason: metav1.StatusReason(fmt.Sprintf(`{"code":%d}`, workloads.DuplicateSpaceNameError)),
+					},
+				}
+				spaceRepo.CreateSpaceReturns(repositories.SpaceRecord{}, err)
+			})
+
+			It("returns an error", func() {
+				expectUnprocessableEntityError("Space 'the-space' already exists.")
+			})
+		})
+
+		When("the space repo returns another error", func() {
+			BeforeEach(func() {
+				spaceRepo.CreateSpaceReturns(repositories.SpaceRecord{}, errors.New("boom"))
+			})
+
+			It("returns unknown error", func() {
+				expectUnknownError()
+			})
+		})
+	})
+
+	Describe("Listing Spaces", func() {
+		BeforeEach(func() {
+			requestMethod = http.MethodGet
 			spaceRepo.FetchSpacesReturns([]repositories.SpaceRecord{
 				{
 					Name:             "alice",
@@ -43,46 +193,39 @@ var _ = Describe("Spaces", func() {
 					UpdatedAt:        now,
 				},
 			}, nil)
-
-			spaceHandler = apis.NewSpaceHandler(spaceRepo, *serverURL)
-			spaceHandler.RegisterRoutes(router)
-
-			req, err = http.NewRequestWithContext(ctx, http.MethodGet, spacesBase, nil)
-			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("returns a list of spaces", func() {
-			router.ServeHTTP(rr, req)
 			Expect(rr.Header().Get("Content-Type")).To(Equal("application/json"))
 
 			Expect(rr.Body.String()).To(MatchJSON(fmt.Sprintf(`{
-           "pagination": {
-              "total_results": 2,
-              "total_pages": 1,
-              "first": {
-                 "href": "%[1]s/v3/spaces?page=1"
-              },
-              "last": {
-                 "href": "%[1]s/v3/spaces?page=1"
-              },
-              "next": null,
-              "previous": null
-           },
-           "resources": [
+                "pagination": {
+                    "total_results": 2,
+                    "total_pages": 1,
+                    "first": {
+                        "href": "%[1]s/v3/spaces?page=1"
+                    },
+                    "last": {
+                        "href": "%[1]s/v3/spaces?page=1"
+                    },
+                    "next": null,
+                    "previous": null
+                },
+                "resources": [
                 {
                     "guid": "a-l-i-c-e",
                     "name": "alice",
                     "created_at": "2021-09-17T15:23:10Z",
                     "updated_at": "2021-09-17T15:23:10Z",
                     "metadata": {
-                      "labels": {},
-                      "annotations": {}
+                        "labels": {},
+                        "annotations": {}
                     },
                     "relationships": {
                         "organization": {
-                          "data": {
-                            "guid": "org-guid-1"
-                          }
+                            "data": {
+                                "guid": "org-guid-1"
+                            }
                         }
                     },
                     "links": {
@@ -100,14 +243,14 @@ var _ = Describe("Spaces", func() {
                     "created_at": "2021-09-17T15:23:10Z",
                     "updated_at": "2021-09-17T15:23:10Z",
                     "metadata": {
-                      "labels": {},
-                      "annotations": {}
+                        "labels": {},
+                        "annotations": {}
                     },
                     "relationships": {
                         "organization": {
-                          "data": {
-                            "guid": "org-guid-2"
-                          }
+                            "data": {
+                                "guid": "org-guid-2"
+                            }
                         }
                     },
                     "links": {
@@ -119,8 +262,8 @@ var _ = Describe("Spaces", func() {
                         }
                     }
                 }
-            ]
-        }`, defaultServerURL)))
+                ]
+            }`, defaultServerURL)))
 
 			Expect(spaceRepo.FetchSpacesCallCount()).To(Equal(1))
 			_, organizationGUIDs, names := spaceRepo.FetchSpacesArgsForCall(0)
@@ -131,7 +274,6 @@ var _ = Describe("Spaces", func() {
 		When("fetching the spaces fails", func() {
 			BeforeEach(func() {
 				spaceRepo.FetchSpacesReturns(nil, errors.New("boom!"))
-				router.ServeHTTP(rr, req)
 			})
 
 			It("returns an error", func() {
@@ -140,11 +282,11 @@ var _ = Describe("Spaces", func() {
 		})
 
 		When("organization_guids are provided as a comma-separated list", func() {
-			It("filters spaces by them", func() {
-				req, err = http.NewRequestWithContext(ctx, http.MethodGet, spacesBase+"?organization_guids=foo,,bar,", nil)
-				Expect(err).NotTo(HaveOccurred())
-				router.ServeHTTP(rr, req)
+			BeforeEach(func() {
+				requestPath = spacesBase + "?organization_guids=foo,,bar,"
+			})
 
+			It("filters spaces by them", func() {
 				Expect(spaceRepo.FetchSpacesCallCount()).To(Equal(1))
 				_, organizationGUIDs, names := spaceRepo.FetchSpacesArgsForCall(0)
 				Expect(organizationGUIDs).To(ConsistOf("foo", "bar"))
@@ -153,11 +295,11 @@ var _ = Describe("Spaces", func() {
 		})
 
 		When("names are provided as a comma-separated list", func() {
-			It("filters spaces by them", func() {
-				req, err = http.NewRequestWithContext(ctx, http.MethodGet, spacesBase+"?organization_guids=org1&names=foo,,bar,", nil)
-				Expect(err).NotTo(HaveOccurred())
-				router.ServeHTTP(rr, req)
+			BeforeEach(func() {
+				requestPath = spacesBase + "?organization_guids=org1&names=foo,,bar,"
+			})
 
+			It("filters spaces by them", func() {
 				Expect(spaceRepo.FetchSpacesCallCount()).To(Equal(1))
 				_, organizationGUIDs, names := spaceRepo.FetchSpacesArgsForCall(0)
 				Expect(organizationGUIDs).To(ConsistOf("org1"))

--- a/payloads/space.go
+++ b/payloads/space.go
@@ -1,0 +1,24 @@
+package payloads
+
+import (
+	"code.cloudfoundry.org/cf-k8s-api/repositories"
+)
+
+type SpaceCreate struct {
+	Name          string             `json:"name" validate:"required"`
+	Relationships SpaceRelationships `json:"relationships" validate:"required"`
+	Metadata      Metadata           `json:"metadata"`
+}
+
+type SpaceRelationships struct {
+	Org Relationship `json:"organization" validate:"required"`
+}
+
+func (p SpaceCreate) ToRecord() repositories.SpaceRecord {
+	return repositories.SpaceRecord{
+		Name:             p.Name,
+		OrganizationGUID: p.Relationships.Org.Data.GUID,
+		Labels:           p.Metadata.Labels,
+		Annotations:      p.Metadata.Annotations,
+	}
+}

--- a/presenter/org.go
+++ b/presenter/org.go
@@ -83,35 +83,15 @@ func ForOrgList(orgs []repositories.OrgRecord, apiBaseURL url.URL) OrgListRespon
 	}
 }
 
+func ForCreateSpace(space repositories.SpaceRecord, apiBaseURL url.URL) SpaceResponse {
+	return toSpaceResponse(space, apiBaseURL)
+}
+
 func ForSpaceList(spaces []repositories.SpaceRecord, apiBaseURL url.URL) SpaceListResponse {
 	spaceResponses := []SpaceResponse{}
 
 	for _, space := range spaces {
-		spaceResponses = append(spaceResponses, SpaceResponse{
-			Name:      space.Name,
-			GUID:      space.GUID,
-			CreatedAt: space.CreatedAt.UTC().Format(time.RFC3339),
-			UpdatedAt: space.CreatedAt.UTC().Format(time.RFC3339),
-			Metadata: Metadata{
-				Labels:      map[string]string{},
-				Annotations: map[string]string{},
-			},
-			Relationships: Relationships{
-				"organization": Relationship{
-					Data: RelationshipData{
-						GUID: space.OrganizationGUID,
-					},
-				},
-			},
-			Links: SpaceLinks{
-				Self: &Link{
-					HREF: buildURL(apiBaseURL).appendPath(spacesBase, space.GUID).build(),
-				},
-				Organization: &Link{
-					HREF: buildURL(apiBaseURL).appendPath(orgsBase, space.OrganizationGUID).build(),
-				},
-			},
-		})
+		spaceResponses = append(spaceResponses, toSpaceResponse(space, apiBaseURL))
 	}
 
 	paginationURL := buildURL(apiBaseURL).appendPath(spacesBase).setQuery("page=1").build()
@@ -127,6 +107,34 @@ func ForSpaceList(spaces []repositories.SpaceRecord, apiBaseURL url.URL) SpaceLi
 			},
 		},
 		Resources: spaceResponses,
+	}
+}
+
+func toSpaceResponse(space repositories.SpaceRecord, apiBaseURL url.URL) SpaceResponse {
+	return SpaceResponse{
+		Name:      space.Name,
+		GUID:      space.GUID,
+		CreatedAt: space.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt: space.CreatedAt.UTC().Format(time.RFC3339),
+		Metadata: Metadata{
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
+		},
+		Relationships: Relationships{
+			"organization": Relationship{
+				Data: RelationshipData{
+					GUID: space.OrganizationGUID,
+				},
+			},
+		},
+		Links: SpaceLinks{
+			Self: &Link{
+				HREF: buildURL(apiBaseURL).appendPath(spacesBase, space.GUID).build(),
+			},
+			Organization: &Link{
+				HREF: buildURL(apiBaseURL).appendPath(orgsBase, space.OrganizationGUID).build(),
+			},
+		},
 	}
 }
 

--- a/repositories/org_repository_test.go
+++ b/repositories/org_repository_test.go
@@ -20,29 +20,44 @@ import (
 
 var _ = Describe("OrgRepository", func() {
 	var (
+		ctx           context.Context
 		rootNamespace string
 		orgRepo       *repositories.OrgRepo
 	)
 
 	BeforeEach(func() {
 		rootNamespace = uuid.NewString()
+		ctx = context.Background()
 		Expect(k8sClient.Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: rootNamespace}})).To(Succeed())
 		orgRepo = repositories.NewOrgRepo(rootNamespace, k8sClient, time.Millisecond*500)
 	})
 
-	Describe("Create Org", func() {
-		var ctx context.Context
+	createOrgAnchor := func(name string) *hnsv1alpha2.SubnamespaceAnchor {
+		guid := uuid.New().String()
+		org := &hnsv1alpha2.SubnamespaceAnchor{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      guid,
+				Namespace: rootNamespace,
+				Labels:    map[string]string{repositories.OrgNameLabel: name},
+			},
+			Status: hnsv1alpha2.SubnamespaceAnchorStatus{
+				State: hnsv1alpha2.Ok,
+			},
+		}
 
-		BeforeEach(func() {
-			ctx = context.Background()
-		})
+		Expect(k8sClient.Create(ctx, org)).To(Succeed())
+		Expect(k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: org.Name}})).To(Succeed())
 
-		updateStatus := func(orgGUID string) {
+		return org
+	}
+
+	Describe("Create", func() {
+		updateStatus := func(anchorNamespace, anchorName string) {
 			defer GinkgoRecover()
 
-			org := &hnsv1alpha2.SubnamespaceAnchor{}
+			anchor := &hnsv1alpha2.SubnamespaceAnchor{}
 			for {
-				err := k8sClient.Get(ctx, client.ObjectKey{Namespace: rootNamespace, Name: orgGUID}, org)
+				err := k8sClient.Get(ctx, client.ObjectKey{Namespace: anchorNamespace, Name: anchorName}, anchor)
 				if err == nil {
 					break
 				}
@@ -51,99 +66,119 @@ var _ = Describe("OrgRepository", func() {
 				continue
 			}
 
-			newOrg := org.DeepCopy()
-			newOrg.Status.State = hnsv1alpha2.Ok
-			Expect(k8sClient.Patch(ctx, newOrg, client.MergeFrom(org))).To(Succeed())
+			newAnchor := anchor.DeepCopy()
+			newAnchor.Status.State = hnsv1alpha2.Ok
+			Expect(k8sClient.Patch(ctx, newAnchor, client.MergeFrom(anchor))).To(Succeed())
 		}
 
-		It("creates a subnamespace anchor in the root namespace", func() {
-			go updateStatus("some-guid")
-			org, err := orgRepo.CreateOrg(ctx, repositories.OrgRecord{
-				GUID: "some-guid",
-				Name: "our-org",
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			namesRequirement, err := labels.NewRequirement(repositories.OrgNameLabel, selection.Equals, []string{"our-org"})
-			Expect(err).NotTo(HaveOccurred())
-			anchorList := hnsv1alpha2.SubnamespaceAnchorList{}
-			err = k8sClient.List(ctx, &anchorList, client.InNamespace(rootNamespace), client.MatchingLabelsSelector{
-				Selector: labels.NewSelector().Add(*namesRequirement),
-			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(anchorList.Items).To(HaveLen(1))
-
-			Expect(org.Name).To(Equal("our-org"))
-			Expect(org.GUID).To(Equal("some-guid"))
-			Expect(org.CreatedAt).To(BeTemporally("~", time.Now(), 2*time.Second))
-			Expect(org.UpdatedAt).To(BeTemporally("~", time.Now(), 2*time.Second))
-		})
-
-		When("the org isn't ready in the timeout", func() {
-			It("returns an error", func() {
-				// we do not call updateStatus() to set state = ok
-				_, err := orgRepo.CreateOrg(ctx, repositories.OrgRecord{
+		Describe("Org", func() {
+			It("creates a subnamespace anchor in the root namespace", func() {
+				go updateStatus(rootNamespace, "some-guid")
+				org, err := orgRepo.CreateOrg(ctx, repositories.OrgRecord{
 					GUID: "some-guid",
 					Name: "our-org",
 				})
-				Expect(err).To(MatchError(ContainSubstring("did not get state 'ok'")))
+				Expect(err).NotTo(HaveOccurred())
+
+				namesRequirement, err := labels.NewRequirement(repositories.OrgNameLabel, selection.Equals, []string{"our-org"})
+				Expect(err).NotTo(HaveOccurred())
+				anchorList := hnsv1alpha2.SubnamespaceAnchorList{}
+				err = k8sClient.List(ctx, &anchorList, client.InNamespace(rootNamespace), client.MatchingLabelsSelector{
+					Selector: labels.NewSelector().Add(*namesRequirement),
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(anchorList.Items).To(HaveLen(1))
+
+				Expect(org.Name).To(Equal("our-org"))
+				Expect(org.GUID).To(Equal("some-guid"))
+				Expect(org.CreatedAt).To(BeTemporally("~", time.Now(), 2*time.Second))
+				Expect(org.UpdatedAt).To(BeTemporally("~", time.Now(), 2*time.Second))
+			})
+
+			When("the org isn't ready in the timeout", func() {
+				It("returns an error", func() {
+					// we do not call updateStatus() to set state = ok
+					_, err := orgRepo.CreateOrg(ctx, repositories.OrgRecord{
+						GUID: "some-guid",
+						Name: "our-org",
+					})
+					Expect(err).To(MatchError(ContainSubstring("did not get state 'ok'")))
+				})
+			})
+
+			When("the client fails to create the org", func() {
+				It("returns an error", func() {
+					_, err := orgRepo.CreateOrg(ctx, repositories.OrgRecord{
+						Name: "this-string-has-illegal-characters-ц",
+					})
+					Expect(err).To(HaveOccurred())
+				})
 			})
 		})
 
-		When("the client fails to create the org", func() {
-			It("returns an error", func() {
-				_, err := orgRepo.CreateOrg(ctx, repositories.OrgRecord{
-					Name: "this-string-has-illegal-characters-ц",
+		Describe("Space", func() {
+			var org *hnsv1alpha2.SubnamespaceAnchor
+
+			BeforeEach(func() {
+				org = createOrgAnchor("org")
+			})
+
+			It("creates a subnamespace anchor in the org namespace", func() {
+				go updateStatus(org.Name, "some-guid")
+
+				space, err := orgRepo.CreateSpace(ctx, repositories.SpaceRecord{
+					GUID:             "some-guid",
+					Name:             "our-space",
+					OrganizationGUID: org.Name,
 				})
-				Expect(err).To(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
+
+				namesRequirement, err := labels.NewRequirement(repositories.SpaceNameLabel, selection.Equals, []string{"our-space"})
+				Expect(err).NotTo(HaveOccurred())
+				anchorList := hnsv1alpha2.SubnamespaceAnchorList{}
+				err = k8sClient.List(ctx, &anchorList, client.InNamespace(org.Name), client.MatchingLabelsSelector{
+					Selector: labels.NewSelector().Add(*namesRequirement),
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(anchorList.Items).To(HaveLen(1))
+
+				Expect(space.Name).To(Equal("our-space"))
+				Expect(space.GUID).To(Equal("some-guid"))
+				Expect(space.CreatedAt).To(BeTemporally("~", time.Now(), 2*time.Second))
+				Expect(space.UpdatedAt).To(BeTemporally("~", time.Now(), 2*time.Second))
+			})
+
+			When("the space isn't ready in the timeout", func() {
+				It("returns an error", func() {
+					// we do not call updateStatus() to set state = ok
+					_, err := orgRepo.CreateSpace(ctx, repositories.SpaceRecord{
+						GUID:             "some-guid",
+						Name:             "our-org",
+						OrganizationGUID: org.Name,
+					})
+					Expect(err).To(MatchError(ContainSubstring("did not get state 'ok'")))
+				})
+			})
+
+			When("the client fails to create the space", func() {
+				It("returns an error", func() {
+					_, err := orgRepo.CreateSpace(ctx, repositories.SpaceRecord{
+						GUID:             "some-guid",
+						Name:             "this-string-has-illegal-characters-ц",
+						OrganizationGUID: org.Name,
+					})
+					Expect(err).To(HaveOccurred())
+				})
 			})
 		})
 	})
 
-	Describe("ListOrgs", func() {
+	Describe("List", func() {
 		var (
 			ctx context.Context
 
-			org1Anchor, org2Anchor, org3Anchor                                                       *hnsv1alpha2.SubnamespaceAnchor
-			space11Anchor, space12Anchor, space21Anchor, space22Anchor, space31Anchor, space32Anchor *hnsv1alpha2.SubnamespaceAnchor
+			org1Anchor, org2Anchor, org3Anchor *hnsv1alpha2.SubnamespaceAnchor
 		)
-
-		createOrgAnchor := func(name string) *hnsv1alpha2.SubnamespaceAnchor {
-			guid := uuid.New().String()
-			org := &hnsv1alpha2.SubnamespaceAnchor{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      guid,
-					Namespace: rootNamespace,
-					Labels:    map[string]string{repositories.OrgNameLabel: name},
-				},
-				Status: hnsv1alpha2.SubnamespaceAnchorStatus{
-					State: hnsv1alpha2.Ok,
-				},
-			}
-
-			Expect(k8sClient.Create(ctx, org)).To(Succeed())
-			Expect(k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: org.Name}})).To(Succeed())
-
-			return org
-		}
-
-		createSpaceAnchor := func(name, orgName string) *hnsv1alpha2.SubnamespaceAnchor {
-			guid := uuid.New().String()
-			space := &hnsv1alpha2.SubnamespaceAnchor{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      guid,
-					Namespace: orgName,
-					Labels:    map[string]string{repositories.SpaceNameLabel: name},
-				},
-				Status: hnsv1alpha2.SubnamespaceAnchorStatus{
-					State: hnsv1alpha2.Ok,
-				},
-			}
-
-			Expect(k8sClient.Create(ctx, space)).To(Succeed())
-
-			return space
-		}
 
 		BeforeEach(func() {
 			ctx = context.Background()
@@ -151,68 +186,11 @@ var _ = Describe("OrgRepository", func() {
 			org1Anchor = createOrgAnchor("org1")
 			org2Anchor = createOrgAnchor("org2")
 			org3Anchor = createOrgAnchor("org3")
-
-			space11Anchor = createSpaceAnchor("space1", org1Anchor.Name)
-			space12Anchor = createSpaceAnchor("space2", org1Anchor.Name)
-
-			space21Anchor = createSpaceAnchor("space1", org2Anchor.Name)
-			space22Anchor = createSpaceAnchor("space3", org2Anchor.Name)
-
-			space31Anchor = createSpaceAnchor("space1", org3Anchor.Name)
-			space32Anchor = createSpaceAnchor("space4", org3Anchor.Name)
 		})
 
-		It("returns the 3 orgs", func() {
-			orgs, err := orgRepo.FetchOrgs(ctx, nil)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(orgs).To(ConsistOf(
-				repositories.OrgRecord{
-					Name:      "org1",
-					CreatedAt: org1Anchor.CreationTimestamp.Time,
-					UpdatedAt: org1Anchor.CreationTimestamp.Time,
-					GUID:      org1Anchor.Name,
-				},
-				repositories.OrgRecord{
-					Name:      "org2",
-					CreatedAt: org2Anchor.CreationTimestamp.Time,
-					UpdatedAt: org2Anchor.CreationTimestamp.Time,
-					GUID:      org2Anchor.Name,
-				},
-				repositories.OrgRecord{
-					Name:      "org3",
-					CreatedAt: org3Anchor.CreationTimestamp.Time,
-					UpdatedAt: org3Anchor.CreationTimestamp.Time,
-					GUID:      org3Anchor.Name,
-				},
-			))
-		})
-
-		When("the org anchor is not ready", func() {
-			BeforeEach(func() {
-				org1AnchorCopy := org1Anchor.DeepCopy()
-				org1AnchorCopy.Status.State = hnsv1alpha2.Missing
-				Expect(k8sClient.Patch(ctx, org1AnchorCopy, client.MergeFrom(org1Anchor))).To(Succeed())
-			})
-
-			It("does not list it", func() {
+		Describe("Orgs", func() {
+			It("returns the 3 orgs", func() {
 				orgs, err := orgRepo.FetchOrgs(ctx, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(orgs).NotTo(ContainElement(
-					repositories.OrgRecord{
-						Name:      "org1",
-						CreatedAt: org1Anchor.CreationTimestamp.Time,
-						UpdatedAt: org1Anchor.CreationTimestamp.Time,
-						GUID:      org1Anchor.Name,
-					},
-				))
-			})
-		})
-
-		When("we filter for org1 and org3", func() {
-			It("returns just those", func() {
-				orgs, err := orgRepo.FetchOrgs(ctx, []string{"org1", "org3"})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(orgs).To(ConsistOf(
@@ -223,6 +201,12 @@ var _ = Describe("OrgRepository", func() {
 						GUID:      org1Anchor.Name,
 					},
 					repositories.OrgRecord{
+						Name:      "org2",
+						CreatedAt: org2Anchor.CreationTimestamp.Time,
+						UpdatedAt: org2Anchor.CreationTimestamp.Time,
+						GUID:      org2Anchor.Name,
+					},
+					repositories.OrgRecord{
 						Name:      "org3",
 						CreatedAt: org3Anchor.CreationTimestamp.Time,
 						UpdatedAt: org3Anchor.CreationTimestamp.Time,
@@ -230,70 +214,89 @@ var _ = Describe("OrgRepository", func() {
 					},
 				))
 			})
-		})
 
-		It("returns the 6 spaces", func() {
-			spaces, err := orgRepo.FetchSpaces(ctx, []string{}, []string{})
-			Expect(err).NotTo(HaveOccurred())
+			When("the org anchor is not ready", func() {
+				BeforeEach(func() {
+					org1AnchorCopy := org1Anchor.DeepCopy()
+					org1AnchorCopy.Status.State = hnsv1alpha2.Missing
+					Expect(k8sClient.Patch(ctx, org1AnchorCopy, client.MergeFrom(org1Anchor))).To(Succeed())
+				})
 
-			Expect(spaces).To(ConsistOf(
-				repositories.SpaceRecord{
-					Name:             "space1",
-					CreatedAt:        space11Anchor.CreationTimestamp.Time,
-					UpdatedAt:        space11Anchor.CreationTimestamp.Time,
-					GUID:             space11Anchor.Name,
-					OrganizationGUID: org1Anchor.Name,
-				},
-				repositories.SpaceRecord{
-					Name:             "space2",
-					CreatedAt:        space12Anchor.CreationTimestamp.Time,
-					UpdatedAt:        space12Anchor.CreationTimestamp.Time,
-					GUID:             space12Anchor.Name,
-					OrganizationGUID: org1Anchor.Name,
-				},
-				repositories.SpaceRecord{
-					Name:             "space1",
-					CreatedAt:        space21Anchor.CreationTimestamp.Time,
-					UpdatedAt:        space21Anchor.CreationTimestamp.Time,
-					GUID:             space21Anchor.Name,
-					OrganizationGUID: org2Anchor.Name,
-				},
-				repositories.SpaceRecord{
-					Name:             "space3",
-					CreatedAt:        space22Anchor.CreationTimestamp.Time,
-					UpdatedAt:        space22Anchor.CreationTimestamp.Time,
-					GUID:             space22Anchor.Name,
-					OrganizationGUID: org2Anchor.Name,
-				},
-				repositories.SpaceRecord{
-					Name:             "space1",
-					CreatedAt:        space31Anchor.CreationTimestamp.Time,
-					UpdatedAt:        space31Anchor.CreationTimestamp.Time,
-					GUID:             space31Anchor.Name,
-					OrganizationGUID: org3Anchor.Name,
-				},
-				repositories.SpaceRecord{
-					Name:             "space4",
-					CreatedAt:        space32Anchor.CreationTimestamp.Time,
-					UpdatedAt:        space32Anchor.CreationTimestamp.Time,
-					GUID:             space32Anchor.Name,
-					OrganizationGUID: org3Anchor.Name,
-				},
-			))
-		})
+				It("does not list it", func() {
+					orgs, err := orgRepo.FetchOrgs(ctx, nil)
+					Expect(err).NotTo(HaveOccurred())
 
-		When("the space anchor is not ready", func() {
-			BeforeEach(func() {
-				space11AnchorCopy := space11Anchor.DeepCopy()
-				space11AnchorCopy.Status.State = hnsv1alpha2.Missing
-				Expect(k8sClient.Patch(ctx, space11AnchorCopy, client.MergeFrom(space11Anchor))).To(Succeed())
+					Expect(orgs).NotTo(ContainElement(
+						repositories.OrgRecord{
+							Name:      "org1",
+							CreatedAt: org1Anchor.CreationTimestamp.Time,
+							UpdatedAt: org1Anchor.CreationTimestamp.Time,
+							GUID:      org1Anchor.Name,
+						},
+					))
+				})
 			})
 
-			It("does not list it", func() {
+			When("we filter for org1 and org3", func() {
+				It("returns just those", func() {
+					orgs, err := orgRepo.FetchOrgs(ctx, []string{"org1", "org3"})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(orgs).To(ConsistOf(
+						repositories.OrgRecord{
+							Name:      "org1",
+							CreatedAt: org1Anchor.CreationTimestamp.Time,
+							UpdatedAt: org1Anchor.CreationTimestamp.Time,
+							GUID:      org1Anchor.Name,
+						},
+						repositories.OrgRecord{
+							Name:      "org3",
+							CreatedAt: org3Anchor.CreationTimestamp.Time,
+							UpdatedAt: org3Anchor.CreationTimestamp.Time,
+							GUID:      org3Anchor.Name,
+						},
+					))
+				})
+			})
+		})
+
+		Describe("Spaces", func() {
+			var space11Anchor, space12Anchor, space21Anchor, space22Anchor, space31Anchor, space32Anchor *hnsv1alpha2.SubnamespaceAnchor
+
+			createSpaceAnchor := func(name, orgName string) *hnsv1alpha2.SubnamespaceAnchor {
+				guid := uuid.New().String()
+				space := &hnsv1alpha2.SubnamespaceAnchor{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      guid,
+						Namespace: orgName,
+						Labels:    map[string]string{repositories.SpaceNameLabel: name},
+					},
+					Status: hnsv1alpha2.SubnamespaceAnchorStatus{
+						State: hnsv1alpha2.Ok,
+					},
+				}
+
+				Expect(k8sClient.Create(ctx, space)).To(Succeed())
+
+				return space
+			}
+
+			BeforeEach(func() {
+				space11Anchor = createSpaceAnchor("space1", org1Anchor.Name)
+				space12Anchor = createSpaceAnchor("space2", org1Anchor.Name)
+
+				space21Anchor = createSpaceAnchor("space1", org2Anchor.Name)
+				space22Anchor = createSpaceAnchor("space3", org2Anchor.Name)
+
+				space31Anchor = createSpaceAnchor("space1", org3Anchor.Name)
+				space32Anchor = createSpaceAnchor("space4", org3Anchor.Name)
+			})
+
+			It("returns the 6 spaces", func() {
 				spaces, err := orgRepo.FetchSpaces(ctx, []string{}, []string{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(spaces).NotTo(ContainElement(
+				Expect(spaces).To(ConsistOf(
 					repositories.SpaceRecord{
 						Name:             "space1",
 						CreatedAt:        space11Anchor.CreationTimestamp.Time,
@@ -301,82 +304,140 @@ var _ = Describe("OrgRepository", func() {
 						GUID:             space11Anchor.Name,
 						OrganizationGUID: org1Anchor.Name,
 					},
+					repositories.SpaceRecord{
+						Name:             "space2",
+						CreatedAt:        space12Anchor.CreationTimestamp.Time,
+						UpdatedAt:        space12Anchor.CreationTimestamp.Time,
+						GUID:             space12Anchor.Name,
+						OrganizationGUID: org1Anchor.Name,
+					},
+					repositories.SpaceRecord{
+						Name:             "space1",
+						CreatedAt:        space21Anchor.CreationTimestamp.Time,
+						UpdatedAt:        space21Anchor.CreationTimestamp.Time,
+						GUID:             space21Anchor.Name,
+						OrganizationGUID: org2Anchor.Name,
+					},
+					repositories.SpaceRecord{
+						Name:             "space3",
+						CreatedAt:        space22Anchor.CreationTimestamp.Time,
+						UpdatedAt:        space22Anchor.CreationTimestamp.Time,
+						GUID:             space22Anchor.Name,
+						OrganizationGUID: org2Anchor.Name,
+					},
+					repositories.SpaceRecord{
+						Name:             "space1",
+						CreatedAt:        space31Anchor.CreationTimestamp.Time,
+						UpdatedAt:        space31Anchor.CreationTimestamp.Time,
+						GUID:             space31Anchor.Name,
+						OrganizationGUID: org3Anchor.Name,
+					},
+					repositories.SpaceRecord{
+						Name:             "space4",
+						CreatedAt:        space32Anchor.CreationTimestamp.Time,
+						UpdatedAt:        space32Anchor.CreationTimestamp.Time,
+						GUID:             space32Anchor.Name,
+						OrganizationGUID: org3Anchor.Name,
+					},
 				))
 			})
-		})
 
-		When("filtering by org guids", func() {
-			It("only retruns the spaces belonging to the specified org guids", func() {
-				spaces, err := orgRepo.FetchSpaces(ctx, []string{string(org1Anchor.Name), string(org3Anchor.Name), "does-not-exist"}, []string{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(spaces).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Name":             Equal("space1"),
-						"OrganizationGUID": Equal(string(org1Anchor.Name)),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Name":             Equal("space1"),
-						"OrganizationGUID": Equal(string(org3Anchor.Name)),
-					}),
-					MatchFields(IgnoreExtras, Fields{"Name": Equal("space2")}),
-					MatchFields(IgnoreExtras, Fields{"Name": Equal("space4")}),
-				))
+			When("the space anchor is not ready", func() {
+				BeforeEach(func() {
+					space11AnchorCopy := space11Anchor.DeepCopy()
+					space11AnchorCopy.Status.State = hnsv1alpha2.Missing
+					Expect(k8sClient.Patch(ctx, space11AnchorCopy, client.MergeFrom(space11Anchor))).To(Succeed())
+				})
+
+				It("does not list it", func() {
+					spaces, err := orgRepo.FetchSpaces(ctx, []string{}, []string{})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(spaces).NotTo(ContainElement(
+						repositories.SpaceRecord{
+							Name:             "space1",
+							CreatedAt:        space11Anchor.CreationTimestamp.Time,
+							UpdatedAt:        space11Anchor.CreationTimestamp.Time,
+							GUID:             space11Anchor.Name,
+							OrganizationGUID: org1Anchor.Name,
+						},
+					))
+				})
 			})
-		})
 
-		When("filtering by space names", func() {
-			It("only retruns the spaces matching the specified names", func() {
-				spaces, err := orgRepo.FetchSpaces(ctx, []string{}, []string{"space1", "space3", "does-not-exist"})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(spaces).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Name":             Equal("space1"),
-						"OrganizationGUID": Equal(string(org1Anchor.Name)),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Name":             Equal("space1"),
-						"OrganizationGUID": Equal(string(org2Anchor.Name)),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Name":             Equal("space1"),
-						"OrganizationGUID": Equal(string(org3Anchor.Name)),
-					}),
-					MatchFields(IgnoreExtras, Fields{"Name": Equal("space3")}),
-				))
+			When("filtering by org guids", func() {
+				It("only retruns the spaces belonging to the specified org guids", func() {
+					spaces, err := orgRepo.FetchSpaces(ctx, []string{string(org1Anchor.Name), string(org3Anchor.Name), "does-not-exist"}, []string{})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(spaces).To(ConsistOf(
+						MatchFields(IgnoreExtras, Fields{
+							"Name":             Equal("space1"),
+							"OrganizationGUID": Equal(string(org1Anchor.Name)),
+						}),
+						MatchFields(IgnoreExtras, Fields{
+							"Name":             Equal("space1"),
+							"OrganizationGUID": Equal(string(org3Anchor.Name)),
+						}),
+						MatchFields(IgnoreExtras, Fields{"Name": Equal("space2")}),
+						MatchFields(IgnoreExtras, Fields{"Name": Equal("space4")}),
+					))
+				})
 			})
-		})
 
-		When("filtering by org guids and space names", func() {
-			It("only retruns the spaces matching the specified names", func() {
-				spaces, err := orgRepo.FetchSpaces(ctx, []string{string(org1Anchor.Name), string(org2Anchor.Name)}, []string{"space1", "space2", "space4"})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(spaces).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Name":             Equal("space1"),
-						"OrganizationGUID": Equal(string(org1Anchor.Name)),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Name":             Equal("space1"),
-						"OrganizationGUID": Equal(string(org2Anchor.Name)),
-					}),
-					MatchFields(IgnoreExtras, Fields{"Name": Equal("space2")}),
-				))
+			When("filtering by space names", func() {
+				It("only retruns the spaces matching the specified names", func() {
+					spaces, err := orgRepo.FetchSpaces(ctx, []string{}, []string{"space1", "space3", "does-not-exist"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(spaces).To(ConsistOf(
+						MatchFields(IgnoreExtras, Fields{
+							"Name":             Equal("space1"),
+							"OrganizationGUID": Equal(string(org1Anchor.Name)),
+						}),
+						MatchFields(IgnoreExtras, Fields{
+							"Name":             Equal("space1"),
+							"OrganizationGUID": Equal(string(org2Anchor.Name)),
+						}),
+						MatchFields(IgnoreExtras, Fields{
+							"Name":             Equal("space1"),
+							"OrganizationGUID": Equal(string(org3Anchor.Name)),
+						}),
+						MatchFields(IgnoreExtras, Fields{"Name": Equal("space3")}),
+					))
+				})
 			})
-		})
 
-		When("filtering by space names that don't exist", func() {
-			It("only retruns the spaces matching the specified names", func() {
-				spaces, err := orgRepo.FetchSpaces(ctx, []string{}, []string{"does-not-exist", "still-does-not-exist"})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(spaces).To(BeEmpty())
+			When("filtering by org guids and space names", func() {
+				It("only retruns the spaces matching the specified names", func() {
+					spaces, err := orgRepo.FetchSpaces(ctx, []string{string(org1Anchor.Name), string(org2Anchor.Name)}, []string{"space1", "space2", "space4"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(spaces).To(ConsistOf(
+						MatchFields(IgnoreExtras, Fields{
+							"Name":             Equal("space1"),
+							"OrganizationGUID": Equal(string(org1Anchor.Name)),
+						}),
+						MatchFields(IgnoreExtras, Fields{
+							"Name":             Equal("space1"),
+							"OrganizationGUID": Equal(string(org2Anchor.Name)),
+						}),
+						MatchFields(IgnoreExtras, Fields{"Name": Equal("space2")}),
+					))
+				})
 			})
-		})
 
-		When("filtering by org uids that don't exist", func() {
-			It("only retruns the spaces matching the specified names", func() {
-				spaces, err := orgRepo.FetchSpaces(ctx, []string{"does-not-exist", "still-does-not-exist"}, []string{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(spaces).To(BeEmpty())
+			When("filtering by space names that don't exist", func() {
+				It("only retruns the spaces matching the specified names", func() {
+					spaces, err := orgRepo.FetchSpaces(ctx, []string{}, []string{"does-not-exist", "still-does-not-exist"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(spaces).To(BeEmpty())
+				})
+			})
+
+			When("filtering by org uids that don't exist", func() {
+				It("only retruns the spaces matching the specified names", func() {
+					spaces, err := orgRepo.FetchSpaces(ctx, []string{"does-not-exist", "still-does-not-exist"}, []string{})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(spaces).To(BeEmpty())
+				})
 			})
 		})
 	})

--- a/tests/e2e/spaces_test.go
+++ b/tests/e2e/spaces_test.go
@@ -1,70 +1,158 @@
 package e2e_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"code.cloudfoundry.org/cf-k8s-api/repositories"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("listing spaces", func() {
-	var orgs []hierarchicalNamespace
+var _ = Describe("Spaces", func() {
+	Describe("creating spaces", func() {
+		var (
+			org                   hierarchicalNamespace
+			spaceName             string
+			createStatusCode      int
+			createResponseHeaders http.Header
+			createResponseBody    map[string]interface{}
+		)
 
-	BeforeEach(func() {
-		orgs = []hierarchicalNamespace{}
-		for i := 1; i <= 3; i++ {
-			orgDetails := createHierarchicalNamespace(rootNamespace, generateGUID("org"+strconv.Itoa(i)), repositories.OrgNameLabel)
-			waitForSubnamespaceAnchor(rootNamespace, orgDetails.guid)
+		createSpace := func(spaceName, orgName string) (int, http.Header, map[string]interface{}) {
+			spacesUrl := apiServerRoot + "/v3/spaces"
 
-			for j := 1; j <= 2; j++ {
-				spaceDetails := createHierarchicalNamespace(orgDetails.guid, generateGUID("space"+strconv.Itoa(j)), repositories.SpaceNameLabel)
-				waitForSubnamespaceAnchor(orgDetails.guid, spaceDetails.guid)
-				orgDetails.children = append(orgDetails.children, spaceDetails)
-			}
+			body := fmt.Sprintf(`{
+                "name": "%s",
+                "relationships": {
+                  "organization": {
+                    "data": {
+                      "guid": "%s"
+                    }
+                  }
+                }
+            }`, spaceName, orgName)
+			req, err := http.NewRequest(http.MethodPost, spacesUrl, strings.NewReader(body))
+			Expect(err).NotTo(HaveOccurred())
 
-			orgs = append(orgs, orgDetails)
+			response, err := http.DefaultClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer response.Body.Close()
+
+			responseMap := map[string]interface{}{}
+			Expect(json.NewDecoder(response.Body).Decode(&responseMap)).To(Succeed())
+
+			return response.StatusCode, response.Header, responseMap
 		}
+
+		BeforeEach(func() {
+			spaceName = generateGUID("space")
+			org = createHierarchicalNamespace(rootNamespace, generateGUID("org"), repositories.OrgNameLabel)
+			waitForSubnamespaceAnchor(rootNamespace, org.guid)
+		})
+
+		AfterEach(func() {
+			spaceGuid, ok := createResponseBody["guid"].(string)
+			Expect(ok).To(BeTrue())
+			deleteSubnamespace(org.guid, spaceGuid)
+			waitForNamespaceDeletion(org.guid, spaceGuid)
+		})
+
+		JustBeforeEach(func() {
+			createStatusCode, createResponseHeaders, createResponseBody = createSpace(spaceName, org.guid)
+		})
+
+		It("creates a space", func() {
+			Expect(createStatusCode).To(Equal(http.StatusCreated))
+			Expect(createResponseHeaders["Content-Type"]).To(ConsistOf("application/json"))
+			Expect(createResponseBody["name"]).To(Equal(spaceName))
+
+			nsName, ok := createResponseBody["guid"].(string)
+			Expect(ok).To(BeTrue())
+			Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: nsName}, &corev1.Namespace{})).To(Succeed())
+		})
+
+		When("the space name already exists", func() {
+			JustBeforeEach(func() {
+				Expect(createStatusCode).To(Equal(http.StatusCreated))
+			})
+
+			It("returns an unprocessable entity error", func() {
+				dupRespCode, _, dupRespBody := createSpace(spaceName, org.guid)
+				Expect(dupRespCode).To(Equal(http.StatusUnprocessableEntity))
+
+				Expect(dupRespBody).To(HaveKeyWithValue("errors", BeAssignableToTypeOf([]interface{}{})))
+				errs := dupRespBody["errors"].([]interface{})
+				Expect(errs[0]).To(SatisfyAll(
+					HaveKeyWithValue("code", BeNumerically("==", 10008)),
+					HaveKeyWithValue("detail", MatchRegexp(fmt.Sprintf(`Space '%s' already exists.`, spaceName))),
+					HaveKeyWithValue("title", Equal("CF-UnprocessableEntity")),
+				))
+			})
+		})
 	})
 
-	AfterEach(func() {
-		for _, org := range orgs {
-			for _, space := range org.children {
-				deleteSubnamespace(org.guid, space.guid)
-				waitForNamespaceDeletion(org.guid, space.guid)
+	Describe("listing spaces", func() {
+		var orgs []hierarchicalNamespace
+
+		BeforeEach(func() {
+			orgs = []hierarchicalNamespace{}
+			for i := 1; i <= 3; i++ {
+				orgDetails := createHierarchicalNamespace(rootNamespace, generateGUID("org"+strconv.Itoa(i)), repositories.OrgNameLabel)
+				waitForSubnamespaceAnchor(rootNamespace, orgDetails.guid)
+
+				for j := 1; j <= 2; j++ {
+					spaceDetails := createHierarchicalNamespace(orgDetails.guid, generateGUID("space"+strconv.Itoa(j)), repositories.SpaceNameLabel)
+					waitForSubnamespaceAnchor(orgDetails.guid, spaceDetails.guid)
+					orgDetails.children = append(orgDetails.children, spaceDetails)
+				}
+
+				orgs = append(orgs, orgDetails)
 			}
-			deleteSubnamespace(rootNamespace, org.guid)
-		}
-	})
+		})
 
-	It("lists all the spaces", func() {
-		Eventually(getSpacesFn(), "60s").Should(SatisfyAll(
-			HaveKeyWithValue("pagination", HaveKeyWithValue("total_results", BeNumerically(">=", 6))),
-			HaveKeyWithValue("resources", ContainElements(
-				HaveKeyWithValue("name", orgs[0].children[0].label),
-				HaveKeyWithValue("name", orgs[0].children[1].label),
-				HaveKeyWithValue("name", orgs[1].children[0].label),
-				HaveKeyWithValue("name", orgs[1].children[1].label),
-				HaveKeyWithValue("name", orgs[2].children[0].label),
-				HaveKeyWithValue("name", orgs[2].children[1].label),
-			))))
-	})
+		AfterEach(func() {
+			for _, org := range orgs {
+				for _, space := range org.children {
+					deleteSubnamespace(org.guid, space.guid)
+					waitForNamespaceDeletion(org.guid, space.guid)
+				}
+				deleteSubnamespace(rootNamespace, org.guid)
+			}
+		})
 
-	When("filtering by organization GUIDs", func() {
-		It("only lists spaces beloging to the orgs", func() {
-			Eventually(getSpacesWithQueryFn(map[string]string{"organization_guids": fmt.Sprintf("%s,%s", orgs[0].guid, orgs[2].guid)}), "60s").Should(
-				HaveKeyWithValue("resources", ConsistOf(
+		It("lists all the spaces", func() {
+			Eventually(getSpacesFn(), "60s").Should(SatisfyAll(
+				HaveKeyWithValue("pagination", HaveKeyWithValue("total_results", BeNumerically(">=", 6))),
+				HaveKeyWithValue("resources", ContainElements(
 					HaveKeyWithValue("name", orgs[0].children[0].label),
 					HaveKeyWithValue("name", orgs[0].children[1].label),
+					HaveKeyWithValue("name", orgs[1].children[0].label),
+					HaveKeyWithValue("name", orgs[1].children[1].label),
 					HaveKeyWithValue("name", orgs[2].children[0].label),
 					HaveKeyWithValue("name", orgs[2].children[1].label),
-				)))
+				))))
+		})
+
+		When("filtering by organization GUIDs", func() {
+			It("only lists spaces beloging to the orgs", func() {
+				Eventually(getSpacesWithQueryFn(map[string]string{"organization_guids": fmt.Sprintf("%s,%s", orgs[0].guid, orgs[2].guid)}), "60s").Should(
+					HaveKeyWithValue("resources", ConsistOf(
+						HaveKeyWithValue("name", orgs[0].children[0].label),
+						HaveKeyWithValue("name", orgs[0].children[1].label),
+						HaveKeyWithValue("name", orgs[2].children[0].label),
+						HaveKeyWithValue("name", orgs[2].children[1].label),
+					)))
+			})
 		})
 	})
 })


### PR DESCRIPTION
# Is there a related GitHub Issue?
https://github.com/cloudfoundry/cf-k8s-api/issues/61

## What is this change about?
Implement `POST /v3/spaces` so that API clients can create spaces

## Does this PR introduce a breaking change?
No

## Acceptance Steps
```
curl "https://api.example.org/v3/spaces" \
  -X POST \
  -H "Content-Type: application/json" \
  -d '{
    "name": "my-space",
    "relationships": {     
      "organization": {    
        "data": {          
           "guid": "<org-guid>"     
        }                  
      }                    
  }'
```
* should succeed
* `curl https://api.example.org/v3/spaces` should list the space

## Tag your pair, your PM, and/or team
@mnitchev @georgethebeatle 

