### PR TITLE
Add notice on README for merge with controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# NOTICE
+## This repository has been merged into [cf-k8s-controllers](https://github.com/cloudfoundry/cf-k8s-controllers) and will be archived.
+### Open issues have been moved and further development will proceed in the controllers repository.
+
 # cf-k8s-api
 This repository contains what we call the "CF API Shim", an experimental implementation of the V3 Cloud Foundry API that is backed entirely by Kubernetes [custom resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
No.

## What is this change about?
This is to put a notice that this repo has been merged into [cf-k8s-controllers](https://github.com/cloudfoundry/cf-k8s-controllers).

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Notification update that requires no testing.

## Tag your pair, your PM, and/or team
@akrishna90 